### PR TITLE
infra: Push-CI 테스트 커버리지 업데이트 파이프라인 추가

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Upload JaCoCo report to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/jacoco/test/jacocoTestReport.xml
           fail_ci_if_error: true
           flags: pr

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,8 +2,8 @@ name: Spring CI for Pull Request
 
 on:
   pull_request:
-    branches: [ main, dev ]
-    types: [opened, synchronize, reopened]
+    branches: [ dev, main ]
+    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: write
@@ -45,10 +45,9 @@ jobs:
       - name: Upload JaCoCo report to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # public repo라면 생략 가능
           files: build/reports/jacoco/test/jacocoTestReport.xml
           fail_ci_if_error: true
-          flags: unittests
+          flags: pr
           verbose: true
 
       - name: Extract JaCoCo Coverage Percentage

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -1,4 +1,37 @@
-name: push-ci.yml
+name: Upload Coverage on Push
+
 on:
+  push:
+    branches: [ dev, main ]
+
+permissions:
+  contents: read
 
 jobs:
+  upload-coverage:
+    name: Upload Coverage to Codecov
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Run Tests and Generate Coverage
+        run: ./gradlew clean test jacocoTestReport --no-daemon
+
+      - name: Upload JaCoCo report to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: true
+          flags: dev
+          verbose: true

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -1,0 +1,4 @@
+name: push-ci.yml
+on:
+
+jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ spy.log
 
 ### Spring Boot ###
 application.yml
+
+### node ###
+node_modules/
+package-lock.json
+package.json


### PR DESCRIPTION
## 🛠️ 인프라 변화

- 기존 하나의 GitHub Actions 워크플로(`pr-ci.yml`)을 분리
- PR용 워크플로: `.github/workflows/pr-ci.yml`
  - PR 생성/수정 시 테스트 및 커버리지 측정 후 PR 코멘트로 결과 표시
- dev 브랜치용 워크플로: `.github/workflows/push-ci.yml` 추가  
  - dev 브랜치로 push(머지)될 경우, 커버리지 재측정 후 Codecov에 업로드하여 뱃지 갱신


## 📝 상세 설명

- 현재 CI는 `pull_request` 이벤트에서만 동작하여, PR에서는 커버리지가 측정되지만 실제 기준 브랜치인 `dev`에서는 커버리지 데이터가 존재하지 않아 Codecov 뱃지가 `unknown`으로 표시되고 있음
- Git-flow 전략을 사용 중이므로 `dev` 브랜치 기준으로 뱃지를 유지하는 것이 적절함

## 🧐 예상 결과

- PR 병합 후 dev 브랜치에 push되면 최신 커버리지가 Codecov에 업로드됨
- Codecov 뱃지(`branch=dev`)가 더 이상 `unknown`이 아닌 실제 수치로 정확히 표시됨

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요 `PR로 테스트`
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #33 
