### PR TITLE
fix: Push-CI Workflows에 Token 설정 추가

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Upload JaCoCo report to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/jacoco/test/jacocoTestReport.xml
           fail_ci_if_error: true
           flags: dev


### PR DESCRIPTION
## 📋 상세 설명

- Push-CI Workflows에 Token 설정이 누락되어서 테스트 커버리지 업데이트가 안됨
  - 사실 근본적으로 Private Repo가 아닌데 왜 토큰 없이는 안되는지 의문이긴 하다...
  - 다만 CodeCov를 공부할 정도로 여유롭지는 않으니 일단 토큰 설정으로 해결

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #35