### PR TITLE
fix: Bulk Insert를 위해 Auction History, Auction Item Option ID 생성 전략을 변경한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ application.yml
 node_modules/
 package-lock.json
 package.json
+
+### temp directory ###
+/temp/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,7 @@ java {
 }
 
 
-val querydslDir = "$buildDir/generated/querydsl"
 
-sourceSets["main"].java.srcDirs(querydslDir)
 
 configurations {
     compileOnly {
@@ -101,11 +99,7 @@ extensions.configure<JacocoPluginExtension>("jacoco") {
     toolVersion = "0.8.10"
 }
 
-// QueryDSL Q 클래스 생성 위치
-tasks.withType<JavaCompile> {
-    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
-    options.annotationProcessorPath = configurations.annotationProcessor.get()
-}
+
 
 tasks.test {
     useJUnitPlatform()

--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,6 +10,9 @@ import until.the.eternity.auctionhistory.application.service.persister.AuctionHi
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,9 +12,6 @@ import until.the.eternity.auctionhistory.application.service.persister.AuctionHi
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -33,7 +33,7 @@ public class AuctionHistoryService {
     }
 
     @Transactional(readOnly = true)
-    public AuctionHistoryDetailResponse<ItemOptionResponse> findByIdOrElseThrow(Long id) {
+    public AuctionHistoryDetailResponse<ItemOptionResponse> findByIdOrElseThrow(String id) {
         AuctionHistory auctionHistory =
                 repository
                         .findById(id)

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionhistory.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,6 +13,8 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,5 +1,6 @@
 package until.the.eternity.auctionhistory.application.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,8 +14,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +8,9 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -8,9 +10,6 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,5 +1,6 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,8 +10,6 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,6 +24,8 @@ public class AuctionHistoryPersister implements AuctionHistoryPersisterPort {
 
         List<AuctionHistory> entities =
                 mapper.toEntityList(duplicateChecker.filterExisting(dtoList), category);
+
+        entities.forEach(AuctionHistory::linkItemOptions);
 
         if (entities.isEmpty()) {
             log.info("> [SCHEDULE] [{}] No new auction history to save", category.getSubCategory());

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +9,8 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.Instant;
-import java.util.List;
 import lombok.*;
 import until.the.eternity.itemoption.domain.entity.ItemOption;
+
+import java.time.Instant;
+import java.util.List;
 
 @Entity
 @Table(name = "auction_history")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
-
 import java.time.Instant;
 import java.util.List;
+import lombok.*;
+import until.the.eternity.itemoption.domain.entity.ItemOption;
 
 @Entity
 @Table(name = "auction_history")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -16,8 +16,8 @@ import until.the.eternity.itemoption.domain.entity.ItemOption;
 public class AuctionHistory {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "auction_buy_id", nullable = false)
+    private String auctionBuyId;
 
     @Column(name = "item_name", nullable = false)
     private String itemName;
@@ -33,9 +33,6 @@ public class AuctionHistory {
 
     @Column(name = "date_auction_buy", nullable = false)
     private Instant dateAuctionBuy;
-
-    @Column(name = "auction_buy_id", nullable = false, unique = true)
-    private String auctionBuyId;
 
     @OneToMany(mappedBy = "auctionHistory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ItemOption> itemOptions;

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.itemoption.domain.entity.ItemOption;
-
-import java.util.List;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -20,6 +20,8 @@ public interface AuctionHistoryMapper {
     AuctionHistoryDetailResponse<ItemOptionResponse> toDto(AuctionHistory entity);
 
     // 하위 매핑
+    @Mapping(target = "auctionHistory", ignore = true)
+    @Mapping(target = "auctionItem", ignore = true)
     ItemOption toEntity(ItemOptionResponse dto);
 
     ItemOptionResponse toDto(ItemOption entity);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.itemoption.domain.entity.ItemOption;
+
+import java.util.List;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -11,7 +11,6 @@ import until.the.eternity.common.enums.ItemCategory;
 public interface OpenApiAuctionHistoryMapper {
 
     @Named("toEntity(OpenApiAuctionHistoryResponse, ItemCategory)")
-    @Mapping(target = "id", ignore = true)
     @Mapping(
             source = "dateAuctionBuy",
             target = "dateAuctionBuy",

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.time.Instant;
-import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,12 +1,11 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.time.Instant;
+import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -16,7 +16,7 @@ public interface AuctionHistoryRepositoryPort {
 
     Page<AuctionHistory> search(AuctionHistorySearchRequest condition, Pageable pageable);
 
-    Optional<AuctionHistory> findByIdWithOptions(Long id);
+    Optional<AuctionHistory> findByIdWithOptions(String id);
 
     boolean existsByAuctionBuyIds(List<String> ids);
 
@@ -24,7 +24,7 @@ public interface AuctionHistoryRepositoryPort {
 
     boolean existsByAuctionBuyIdIn(List<String> ids);
 
-    Optional<AuctionHistory> findById(Long id);
+    Optional<AuctionHistory> findById(String id);
 
     void saveAll(List<AuctionHistory> newEntities);
 

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,13 +1,14 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionhistory.domain.service;
 
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,13 +1,14 @@
 package until.the.eternity.auctionhistory.domain.service;
 
-import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,8 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,9 +1,8 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,14 +1,15 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,15 +1,14 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -12,7 +12,7 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 
 @Repository
 public interface AuctionHistoryJpaRepository
-        extends JpaRepository<AuctionHistory, Long>, JpaSpecificationExecutor<AuctionHistory> {
+        extends JpaRepository<AuctionHistory, String>, JpaSpecificationExecutor<AuctionHistory> {
 
     List<AuctionHistory> findAllByAuctionBuyIdIn(List<String> auctionBuyIds);
 
@@ -35,5 +35,5 @@ public interface AuctionHistoryJpaRepository
     Optional<Instant> findLatestDateAuctionBuyBySubCategory(String topCategory, String subCategory);
 
     @EntityGraph(attributePaths = "itemOptions")
-    Optional<AuctionHistory> findWithItemOptionsById(Long id);
+    Optional<AuctionHistory> findWithItemOptionsByAuctionBuyId(String id);
 }

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -2,6 +2,7 @@ package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -10,8 +11,6 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.entity.QAuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -2,7 +2,6 @@ package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -11,6 +10,8 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.entity.QAuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -31,8 +31,8 @@ public class AuctionHistoryRepositoryPortImpl implements AuctionHistoryRepositor
     }
 
     @Override
-    public Optional<AuctionHistory> findByIdWithOptions(Long id) {
-        return jpaRepository.findWithItemOptionsById(id);
+    public Optional<AuctionHistory> findByIdWithOptions(String id) {
+        return jpaRepository.findWithItemOptionsByAuctionBuyId(id);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class AuctionHistoryRepositoryPortImpl implements AuctionHistoryRepositor
     }
 
     @Override
-    public Optional<AuctionHistory> findById(Long id) {
+    public Optional<AuctionHistory> findById(String id) {
         return jpaRepository.findById(id);
     }
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,8 +1,5 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +8,10 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,17 +1,19 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository
@@ -20,6 +22,10 @@ public class AuctionHistoryRepositoryPortImpl implements AuctionHistoryRepositor
 
     private final AuctionHistoryJpaRepository jpaRepository;
     private final AuctionHistoryQueryDslRepository queryDslRepository;
+    private final EntityManager em;
+
+    @Value("${spring.jpa.properties.hibernate.jdbc.batch_size:500}")
+    private int batchSize;
 
     @Override
     public List<AuctionHistory> findAllByAuctionBuyIds(List<String> auctionBuyIds) {
@@ -57,8 +63,19 @@ public class AuctionHistoryRepositoryPortImpl implements AuctionHistoryRepositor
     }
 
     @Override
+    @Transactional
     public void saveAll(List<AuctionHistory> newEntities) {
-        jpaRepository.saveAll(newEntities);
+        if (newEntities.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0; i < newEntities.size(); i += batchSize) {
+            int toIndex = Math.min(i + batchSize, newEntities.size());
+            List<AuctionHistory> subList = newEntities.subList(i, toIndex);
+            jpaRepository.saveAll(subList);
+            em.flush();
+            em.clear();
+        }
     }
 
     @Override

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,9 +1,6 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -14,6 +11,10 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,9 +2,10 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
+
 import java.time.Instant;
 import java.util.List;
-import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,10 +2,9 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
-
 import java.time.Instant;
 import java.util.List;
+import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
@@ -36,7 +36,7 @@ public class AuctionHistoryController {
     @GetMapping("/{id}")
     @Operation(summary = "경매장 거래 내역 단건 조회", description = "Nexon Open API 경매장 거래 내역 조회")
     public ResponseEntity<AuctionHistoryDetailResponse<ItemOptionResponse>> findById(
-            @PathVariable Long id) {
+            @PathVariable String id) {
         AuctionHistoryDetailResponse<ItemOptionResponse> result = service.findByIdOrElseThrow(id);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.List;
 
 public record AuctionHistoryDetailResponse<ItemOptionResponse>(
-        Long id,
         String itemName,
         String itemDisplayName,
         Long itemCount,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.*;
 import until.the.eternity.itemoption.domain.entity.ItemOption;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "auction_item")

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.*;
+import until.the.eternity.itemoption.domain.entity.ItemOption;
 
 @Entity
 @Table(name = "auction_item")

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,11 +1,12 @@
 package until.the.eternity.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,12 +1,11 @@
 package until.the.eternity.common.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
+
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
-
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,9 +1,8 @@
 package until.the.eternity.common.response;
 
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,8 +1,9 @@
 package until.the.eternity.common.response;
 
-import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,6 +1,7 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,7 +1,6 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,12 +1,11 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
-
-import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,11 +1,12 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,11 +1,10 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
-
-import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,10 +1,11 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
+
+import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,10 +2,9 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
-
-import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,9 +2,10 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,8 +1,9 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "horn_bugle_world_history")

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,9 +1,8 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(name = "horn_bugle_world_history")

--- a/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
+++ b/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
@@ -2,6 +2,7 @@ package until.the.eternity.itemminprice.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.service.ItemDailyMinPriceService;
-
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
+++ b/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
@@ -2,7 +2,6 @@ package until.the.eternity.itemminprice.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.service.ItemDailyMinPriceService;
+
+import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
@@ -1,6 +1,7 @@
 package until.the.eternity.itemminprice.domain.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 

--- a/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
@@ -1,7 +1,6 @@
 package until.the.eternity.itemminprice.domain.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 

--- a/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
@@ -2,10 +2,9 @@ package until.the.eternity.itemminprice.domain.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
@@ -2,9 +2,10 @@ package until.the.eternity.itemminprice.domain.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.itemminprice.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ItemDailyMinPriceMapper {

--- a/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.itemminprice.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
-
-import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ItemDailyMinPriceMapper {

--- a/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
+++ b/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.itemminprice.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,6 +8,9 @@ import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResp
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
 import until.the.eternity.itemminprice.domain.mapper.ItemDailyMinPriceMapper;
 import until.the.eternity.itemminprice.repository.ItemDailyMinPriceRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
+++ b/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
@@ -1,5 +1,7 @@
 package until.the.eternity.itemminprice.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,9 +10,6 @@ import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResp
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
 import until.the.eternity.itemminprice.domain.mapper.ItemDailyMinPriceMapper;
 import until.the.eternity.itemminprice.repository.ItemDailyMinPriceRepository;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
+++ b/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
@@ -1,6 +1,7 @@
 package until.the.eternity.itemoption.domain.entity;
 
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +17,13 @@ import until.the.eternity.auctionitem.domain.entity.AuctionItem;
 @Builder
 public class ItemOption {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Id private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "auction_history_id", nullable = true)
+    @JoinColumn(
+            name = "auction_history_id",
+            referencedColumnName = "auction_buy_id",
+            nullable = false)
     private AuctionHistory auctionHistory;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,6 +44,11 @@ public class ItemOption {
 
     @Column(name = "option_desc", columnDefinition = "TEXT")
     private String optionDesc;
+
+    @PrePersist
+    public void createId() {
+        this.id = UUID.randomUUID().toString();
+    }
 
     public void setAuctionHistory(AuctionHistory auctionHistory) {
 

--- a/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
+++ b/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
@@ -18,7 +18,9 @@ import java.util.UUID;
 @Builder
 public class ItemOption {
 
-    @Id private String id;
+    @Id
+    @Column(name = "id")
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(

--- a/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
+++ b/src/main/java/until/the/eternity/itemoption/domain/entity/ItemOption.java
@@ -1,13 +1,14 @@
 package until.the.eternity.itemoption.domain.entity;
 
 import jakarta.persistence.*;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionitem.domain.entity.AuctionItem;
+
+import java.util.UUID;
 
 @Entity
 @Table(name = "auction_item_option")

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -23,7 +23,7 @@ spring:
       static-locations: classpath:/static/
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:${DB_PORT}/${DB_SCHEMA}
+    url: jdbc:mysql://localhost:${DB_PORT}/${DB_SCHEMA}?rewriteBatchedStatements=true
     username: ${DB_USER}
     password: ${DB_PASSWORD}
   jpa:

--- a/src/main/resources/db/migration/V4__change_auction_history_pk.sql
+++ b/src/main/resources/db/migration/V4__change_auction_history_pk.sql
@@ -1,19 +1,19 @@
 -- auction_item_option의 FK 제약 조건(fk_option_history)을 삭제
-ALTER TABLE auction_item_option_2
-    DROP FOREIGN KEY fk_option_history_2;
+ALTER TABLE auction_item_option
+    DROP FOREIGN KEY fk_option_history;
 
 -- auction_history의 PK 변경 후 기존 id 제거
-ALTER TABLE auction_history_2
+ALTER TABLE auction_history
     DROP PRIMARY KEY,
     ADD PRIMARY KEY (auction_buy_id),
     DROP COLUMN id;
 
 -- auction_item_option comment 변경
-ALTER TABLE auction_item_option_2
+ALTER TABLE auction_item_option
     MODIFY auction_history_id varchar(255) NULL COMMENT 'auction_history 테이블의 외래 키 (auction_history.auction_buy_id)';
 
 -- auction_item_option -> auction_history 제약 조건 추가
-ALTER TABLE auction_item_option_2
-    ADD CONSTRAINT fk_option_history_2
-        FOREIGN KEY (auction_history_id) REFERENCES auction_history_2 (auction_buy_id)
+ALTER TABLE auction_item_option
+    ADD CONSTRAINT fk_option_history
+        FOREIGN KEY (auction_history_id) REFERENCES auction_history (auction_buy_id)
             ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V4__change_auction_history_pk.sql
+++ b/src/main/resources/db/migration/V4__change_auction_history_pk.sql
@@ -1,0 +1,19 @@
+-- auction_item_option의 FK 제약 조건(fk_option_history)을 삭제
+ALTER TABLE auction_item_option_2
+    DROP FOREIGN KEY fk_option_history_2;
+
+-- auction_history의 PK 변경 후 기존 id 제거
+ALTER TABLE auction_history_2
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (auction_buy_id),
+    DROP COLUMN id;
+
+-- auction_item_option comment 변경
+ALTER TABLE auction_item_option_2
+    MODIFY auction_history_id varchar(255) NULL COMMENT 'auction_history 테이블의 외래 키 (auction_history.auction_buy_id)';
+
+-- auction_item_option -> auction_history 제약 조건 추가
+ALTER TABLE auction_item_option_2
+    ADD CONSTRAINT fk_option_history_2
+        FOREIGN KEY (auction_history_id) REFERENCES auction_history_2 (auction_buy_id)
+            ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V5__change_item_option_pk.sql
+++ b/src/main/resources/db/migration/V5__change_item_option_pk.sql
@@ -1,0 +1,19 @@
+-- 기존 FK, PK 제약 조건 삭제
+ALTER TABLE auction_item_option
+    DROP FOREIGN KEY fk_option_history,
+    DROP PRIMARY KEY;
+
+-- 기존 id 컬럼 삭제
+ALTER TABLE auction_item_option
+    DROP COLUMN id;
+
+-- 새로운 PK 컬럼 추가
+ALTER TABLE auction_item_option
+    ADD COLUMN item_option_id VARCHAR(36) NOT NULL COMMENT 'ItemOption의 고유 식별자 (UUID)' FIRST,
+    ADD PRIMARY KEY (item_option_id);
+
+-- FK 제약 조건 다시 추가
+ALTER TABLE auction_item_option
+    ADD CONSTRAINT fk_option_history
+        FOREIGN KEY (auction_history_id) REFERENCES auction_history (auction_buy_id)
+            ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V6__change_item_option_column_name.sql
+++ b/src/main/resources/db/migration/V6__change_item_option_column_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE auction_item_option
+    CHANGE COLUMN item_option_id id VARCHAR(36) NOT NULL COMMENT 'ItemOption의 고유 식별자 (UUID)';

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -68,7 +68,7 @@ class AuctionHistoryServiceTest {
     @DisplayName("데이터가 존재하면 findByIdOrElseThrow는 dto를 반환한다")
     void findByIdOrElseThrow_should_return_dto_when_entity_exists() {
         // given
-        Long id = 1L;
+        String id = "test-id";
         AuctionHistory entity = new AuctionHistory();
         AuctionHistoryDetailResponse<ItemOptionResponse> dto =
                 mock(AuctionHistoryDetailResponse.class);
@@ -89,7 +89,7 @@ class AuctionHistoryServiceTest {
     @DisplayName("검색 경매장 거래 내역 ID가 존재하지 않으면 예외처리를 한다")
     void findByIdOrElseThrow_should_throw_exception_when_not_found() {
         // given
-        Long id = 999L;
+        String id = "non-existing-id";
         when(repositoryPort.findById(id)).thenReturn(Optional.empty());
 
         // expect

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.auctionhistory.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,13 +26,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryServiceTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -1,11 +1,5 @@
 package until.the.eternity.auctionhistory.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +20,13 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryServiceTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
@@ -1,12 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
-import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +13,14 @@ import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryCli
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryListResponse;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryFetcherTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
@@ -1,5 +1,12 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,14 +20,6 @@ import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryCli
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryListResponse;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryFetcherTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
@@ -1,11 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +12,13 @@ import until.the.eternity.auctionhistory.domain.mapper.OpenApiAuctionHistoryMapp
 import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateChecker;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryPersisterTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,13 +18,6 @@ import until.the.eternity.auctionhistory.domain.mapper.OpenApiAuctionHistoryMapp
 import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateChecker;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryPersisterTest {


### PR DESCRIPTION
## 📋 상세 설명

- ID 생성전략 (IDENTITY)의 문제로 Auction History insert시 bulk-insert가 아닌 row-by-row insert가 발생해서, 메모리를 많이 차지했다.
- Bulk insert를 위해서 Auction History는 Open API 데이터에서 제공하는 auction_buy_id를 id처럼 사용하고, auction_item_options는 기존의 id drop 후 uuid pk를 추가해주었다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [ ] 코드가 테스트 되었나요 // 작업량이 많은 관계로 테스트 코드는 이후에 추가
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #46 
