### PR TITLE
fix: AuctionItemOption의 ID 데이터 타입 미변경으로 인한 에러 해결

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/ItemOptionResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/ItemOptionResponse.java
@@ -1,7 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 public record ItemOptionResponse(
-        Long id,
+        String id,
         String optionType,
         String optionSubType,
         String optionValue,


### PR DESCRIPTION
## 📋 상세 설명

- INSERT 시 bulk-insert를 하고자 AuctionItemOption 테이블의 id를 uuid로 변경했는데, 응답 response의 데이터 타입을 변경하지 않아, 경매거래내역 조회 API를 사용하면 에러가 난다.
- 다행히 데이터 적재 시에는 정상적으로 실행된다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #52 
