### PR TITLE
feat: 아이템 옵션 값 정보 테이블 및 조회 기능 구현

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,9 +12,6 @@ import until.the.eternity.auctionhistory.application.service.persister.AuctionHi
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.application.service;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,8 +15,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -8,9 +10,6 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,5 +1,6 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,8 +10,6 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
-
 import java.time.Instant;
 import java.util.List;
+import lombok.*;
+import until.the.eternity.auctionitemoption.domain.entity.AuctionItemOption;
 
 @Entity
 @Table(name = "auction_history")
@@ -36,7 +35,7 @@ public class AuctionHistory {
     private Instant dateAuctionBuy;
 
     @OneToMany(mappedBy = "auctionHistory", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ItemOption> itemOptions;
+    private List<AuctionItemOption> auctionItemOptions;
 
     @Column(name = "item_sub_category", nullable = false)
     private String itemSubCategory;
@@ -45,8 +44,8 @@ public class AuctionHistory {
     private String itemTopCategory;
 
     public AuctionHistory linkItemOptions() {
-        if (this.itemOptions != null) {
-            for (ItemOption o : this.itemOptions) {
+        if (this.auctionItemOptions != null) {
+            for (AuctionItemOption o : this.auctionItemOptions) {
                 o.setAuctionHistory(this);
             }
         }

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
-
-import java.util.List;
+import until.the.eternity.auctionitemoption.domain.entity.AuctionItemOption;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto
@@ -17,17 +16,17 @@ import java.util.List;
 public interface AuctionHistoryMapper {
 
     // Entity → DTO
-    @Mapping(target = "itemOptions", source = "itemOptions")
+    @Mapping(target = "itemOptions", source = "auctionItemOptions")
     AuctionHistoryDetailResponse<ItemOptionResponse> toDto(AuctionHistory entity);
 
     // 하위 매핑
     @Mapping(target = "auctionHistory", ignore = true)
     @Mapping(target = "auctionItem", ignore = true)
-    ItemOption toEntity(ItemOptionResponse dto);
+    AuctionItemOption toEntity(ItemOptionResponse dto);
 
-    ItemOptionResponse toDto(ItemOption entity);
+    ItemOptionResponse toDto(AuctionItemOption entity);
 
-    List<ItemOption> toEntityList(List<ItemOptionResponse> dtoList);
+    List<AuctionItemOption> toEntityList(List<ItemOptionResponse> dtoList);
 
-    List<ItemOptionResponse> toDtoList(List<ItemOption> entityList);
+    List<ItemOptionResponse> toDtoList(List<AuctionItemOption> entityList);
 }

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,12 +1,11 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.time.Instant;
+import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {
@@ -16,7 +15,7 @@ public interface OpenApiAuctionHistoryMapper {
             source = "dateAuctionBuy",
             target = "dateAuctionBuy",
             qualifiedByName = "stringToInstant")
-    @Mapping(source = "openApiItemOptionResponses", target = "itemOptions")
+    @Mapping(source = "openApiAuctionItemOptionResponse", target = "auctionItemOptions")
     @Mapping(
             target = "itemTopCategory",
             expression = "java(ItemCategory.findTopCategory(dto.itemSubCategory()))")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiItemOptionMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiItemOptionMapper.java
@@ -2,8 +2,8 @@ package until.the.eternity.auctionhistory.domain.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
+import until.the.eternity.auctionitemoption.domain.entity.AuctionItemOption;
 
 @Mapper(componentModel = "spring")
 public interface OpenApiItemOptionMapper {
@@ -11,5 +11,5 @@ public interface OpenApiItemOptionMapper {
     @Mapping(target = "id", ignore = true) // PK 자동 생성
     @Mapping(target = "auctionHistory", ignore = true)
     @Mapping(target = "auctionItem", ignore = true)
-    ItemOption toEntity(OpenApiItemOptionResponse itemOption);
+    AuctionItemOption toEntity(OpenApiAuctionItemOptionResponse itemOption);
 }

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionhistory.domain.service;
 
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,9 +1,8 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,15 +1,14 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -2,6 +2,7 @@ package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -10,8 +11,6 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.entity.QAuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -26,7 +25,7 @@ class AuctionHistoryQueryDslRepository {
         List<AuctionHistory> content =
                 queryFactory
                         .selectFrom(ah)
-                        .leftJoin(ah.itemOptions)
+                        .leftJoin(ah.auctionItemOptions)
                         .fetchJoin()
                         .where(builder)
                         .offset(pageable.getOffset())

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,6 +1,9 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -11,10 +14,6 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,10 +2,9 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import until.the.eternity.itemoption.domain.dto.external.OpenApiItemOptionResponse;
-
 import java.time.Instant;
 import java.util.List;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,
@@ -17,4 +16,5 @@ public record OpenApiAuctionHistoryResponse(
                 @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
                 Instant dateAuctionBuy,
         @JsonProperty("auction_buy_id") String auctionBuyId,
-        @JsonProperty("item_option") List<OpenApiItemOptionResponse> openApiItemOptionResponses) {}
+        @JsonProperty("item_option")
+                List<OpenApiAuctionItemOptionResponse> openApiAuctionItemOptionResponse) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionItem.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.itemoption.domain.entity.ItemOption;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.*;
+import until.the.eternity.auctionitemoption.domain.entity.AuctionItemOption;
 
 @Entity
 @Table(name = "auction_item")
@@ -36,5 +35,5 @@ public class AuctionItem {
     private LocalDateTime dateAuctionExpire;
 
     @OneToMany(mappedBy = "auctionItem", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ItemOption> itemOptions;
+    private List<AuctionItemOption> auctionItemOptions;
 }

--- a/src/main/java/until/the/eternity/auctionitemoption/domain/dto/external/OpenApiAuctionItemOptionResponse.java
+++ b/src/main/java/until/the/eternity/auctionitemoption/domain/dto/external/OpenApiAuctionItemOptionResponse.java
@@ -1,8 +1,8 @@
-package until.the.eternity.itemoption.domain.dto.external;
+package until.the.eternity.auctionitemoption.domain.dto.external;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record OpenApiItemOptionResponse(
+public record OpenApiAuctionItemOptionResponse(
         @JsonProperty("option_type") String optionType,
         @JsonProperty("option_sub_type") String optionSubType,
         @JsonProperty("option_value") String optionValue,

--- a/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionItemOption.java
@@ -1,6 +1,7 @@
-package until.the.eternity.itemoption.domain.entity;
+package until.the.eternity.auctionitemoption.domain.entity;
 
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,15 +9,13 @@ import lombok.NoArgsConstructor;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionitem.domain.entity.AuctionItem;
 
-import java.util.UUID;
-
 @Entity
 @Table(name = "auction_item_option")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ItemOption {
+public class AuctionItemOption {
 
     @Id
     @Column(name = "id")
@@ -57,15 +56,15 @@ public class ItemOption {
 
         // 이전 연관관계 정리
         if (this.auctionHistory != null) {
-            this.auctionHistory.getItemOptions().remove(this);
+            this.auctionHistory.getAuctionItemOptions().remove(this);
         }
 
         // 새 연관관계 설정
         this.auctionHistory = auctionHistory;
 
         // 반대 쪽 컬렉션 동기화
-        if (auctionHistory != null && !auctionHistory.getItemOptions().contains(this)) {
-            auctionHistory.getItemOptions().add(this);
+        if (auctionHistory != null && !auctionHistory.getAuctionItemOptions().contains(this)) {
+            auctionHistory.getAuctionItemOptions().add(this);
         }
     }
 }

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,12 +1,11 @@
 package until.the.eternity.common.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
-
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,9 +1,8 @@
 package until.the.eternity.common.response;
 
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,7 +1,6 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,12 +1,11 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
-
-import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,11 +1,10 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
-
-import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,10 +2,9 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
-
-import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,9 +1,8 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(name = "horn_bugle_world_history")

--- a/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
+++ b/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
@@ -1,5 +1,6 @@
 package until.the.eternity.iteminfo.application.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,8 +8,6 @@ import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
@@ -1,8 +1,7 @@
 package until.the.eternity.iteminfo.domain.repository;
 
-import until.the.eternity.iteminfo.domain.entity.ItemInfo;
-
 import java.util.List;
+import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 
 public interface ItemInfoRepositoryPort {
     List<ItemInfo> findAll();

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
@@ -1,14 +1,12 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 
-import java.util.List;
-
 public interface ItemInfoJpaRepository
         extends JpaRepository<ItemInfo, String>, JpaSpecificationExecutor<ItemInfo> {
-
 
     List<ItemInfo> findByTopCategory(String topCategory);
 

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
@@ -1,11 +1,10 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -3,6 +3,7 @@ package until.the.eternity.iteminfo.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,8 +14,6 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.iteminfo.application.service.ItemInfoService;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/item-infos")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
@@ -1,12 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-import until.the.eternity.common.enums.ItemCategory;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import until.the.eternity.common.enums.ItemCategory;
 
 @Getter
 @Builder

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
@@ -1,11 +1,10 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import until.the.eternity.iteminfo.domain.entity.ItemInfo;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 
 @Builder
 @Schema(description = "아이템 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
+++ b/src/main/java/until/the/eternity/itemminprice/controller/ItemDailyMinPriceController.java
@@ -2,6 +2,7 @@ package until.the.eternity.itemminprice.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.service.ItemDailyMinPriceService;
-
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/dto/response/ItemDailyMinPriceResponseDto.java
@@ -1,7 +1,6 @@
 package until.the.eternity.itemminprice.domain.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 

--- a/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/entity/ItemDailyMinPrice.java
@@ -2,10 +2,9 @@ package until.the.eternity.itemminprice.domain.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
+++ b/src/main/java/until/the/eternity/itemminprice/domain/mapper/ItemDailyMinPriceMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.itemminprice.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResponseDto;
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
-
-import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ItemDailyMinPriceMapper {

--- a/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
+++ b/src/main/java/until/the/eternity/itemminprice/service/ItemDailyMinPriceService.java
@@ -1,5 +1,7 @@
 package until.the.eternity.itemminprice.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,9 +10,6 @@ import until.the.eternity.itemminprice.domain.dto.response.ItemDailyMinPriceResp
 import until.the.eternity.itemminprice.domain.entity.ItemDailyMinPrice;
 import until.the.eternity.itemminprice.domain.mapper.ItemDailyMinPriceMapper;
 import until.the.eternity.itemminprice.repository.ItemDailyMinPriceRepository;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
@@ -1,0 +1,20 @@
+package until.the.eternity.itemoptioninfo.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemOptionInfoService {
+
+    private final ItemOptionInfoRepositoryPort itemOptionInfoRepositoryPort;
+
+    public List<ItemOptionInfo> findAll() {
+        return itemOptionInfoRepositoryPort.findAll();
+    }
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfo.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfo.java
@@ -1,0 +1,21 @@
+package until.the.eternity.itemoptioninfo.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "item_option_value_info")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemOptionInfo {
+
+    @EmbeddedId private ItemOptionInfoId id;
+
+    @Column(name = "option_desc", columnDefinition = "text")
+    private String optionDesc;
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
@@ -1,0 +1,44 @@
+package until.the.eternity.itemoptioninfo.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemOptionInfoId implements Serializable {
+
+    @Column(name = "option_type", length = 100)
+    private String optionType;
+
+    @Column(name = "option_sub_type", length = 100)
+    private String optionSubType;
+
+    @Column(name = "option_value", length = 255)
+    private String optionValue;
+
+    @Column(name = "option_value2", length = 255)
+    private String optionValue2;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ItemOptionInfoId that = (ItemOptionInfoId) o;
+        return Objects.equals(optionType, that.optionType)
+                && Objects.equals(optionSubType, that.optionSubType)
+                && Objects.equals(optionValue, that.optionValue)
+                && Objects.equals(optionValue2, that.optionValue2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(optionType, optionSubType, optionValue, optionValue2);
+    }
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/mapper/ItemOptionInfoMapper.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/mapper/ItemOptionInfoMapper.java
@@ -1,0 +1,19 @@
+package until.the.eternity.itemoptioninfo.domain.mapper;
+
+import org.springframework.stereotype.Component;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
+
+@Component
+public class ItemOptionInfoMapper {
+
+    public ItemOptionInfoResponse toItemOptionInfoResponse(ItemOptionInfo itemOptionInfo) {
+        return ItemOptionInfoResponse.builder()
+                .optionType(itemOptionInfo.getId().getOptionType())
+                .optionSubType(itemOptionInfo.getId().getOptionSubType())
+                .optionValue(itemOptionInfo.getId().getOptionValue())
+                .optionValue2(itemOptionInfo.getId().getOptionValue2())
+                .optionDesc(itemOptionInfo.getOptionDesc())
+                .build();
+    }
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
@@ -1,0 +1,8 @@
+package until.the.eternity.itemoptioninfo.domain.repository;
+
+import java.util.List;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+
+public interface ItemOptionInfoRepositoryPort {
+    List<ItemOptionInfo> findAll();
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoJpaRepository.java
@@ -1,0 +1,8 @@
+package until.the.eternity.itemoptioninfo.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
+
+public interface ItemOptionInfoJpaRepository
+        extends JpaRepository<ItemOptionInfo, ItemOptionInfoId> {}

--- a/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
@@ -1,0 +1,19 @@
+package until.the.eternity.itemoptioninfo.infrastructure.persistence;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemOptionInfoRepositoryPortImpl implements ItemOptionInfoRepositoryPort {
+
+    private final ItemOptionInfoJpaRepository itemOptionInfoJpaRepository;
+
+    @Override
+    public List<ItemOptionInfo> findAll() {
+        return itemOptionInfoJpaRepository.findAll();
+    }
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
@@ -1,0 +1,31 @@
+package until.the.eternity.itemoptioninfo.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.itemoptioninfo.application.service.ItemOptionInfoService;
+import until.the.eternity.itemoptioninfo.domain.mapper.ItemOptionInfoMapper;
+import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
+
+@RestController
+@RequestMapping("/api/v1/item-option-infos")
+@RequiredArgsConstructor
+@Tag(name = "아이템 옵션 정보", description = "아이템 옵션 정보 API")
+public class ItemOptionInfoController {
+
+    private final ItemOptionInfoService itemOptionInfoService;
+    private final ItemOptionInfoMapper itemOptionInfoMapper;
+
+    @GetMapping
+    @Operation(summary = "아이템 옵션 정보 전체 조회", description = "모든 아이템 옵션 정보를 조회합니다.")
+    public List<ItemOptionInfoResponse> findAll() {
+        return itemOptionInfoService.findAll().stream()
+                .map(itemOptionInfoMapper::toItemOptionInfoResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/dto/response/ItemOptionInfoResponse.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/dto/response/ItemOptionInfoResponse.java
@@ -1,0 +1,25 @@
+package until.the.eternity.itemoptioninfo.interfaces.rest.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemOptionInfoResponse {
+
+    @Schema(description = "아이템 옵션 유형", example = "STR")
+    private String optionType;
+
+    @Schema(description = "아이템 옵션 하위 유형", example = "+")
+    private String optionSubType;
+
+    @Schema(description = "아이템 옵션 값", example = "10")
+    private String optionValue;
+
+    @Schema(description = "아이템 옵션 값 2", example = "10%")
+    private String optionValue2;
+
+    @Schema(description = "아이템 옵션 부가 정보", example = "힘이 10 증가합니다.")
+    private String optionDesc;
+}

--- a/src/main/resources/db/migration/V7__create_item_option_info_table.sql
+++ b/src/main/resources/db/migration/V7__create_item_option_info_table.sql
@@ -1,0 +1,13 @@
+create table item_option_value_info
+(
+    option_type      varchar(100) null comment '아이템 옵션 유형',
+    option_sub_type  varchar(100) null comment '아이템 옵션 하위 유형',
+    option_value     varchar(255) null comment '아이템 옵션 값',
+    option_value2    varchar(255) null comment '아이템 옵션 값 2',
+    option_desc      text         null comment '아이템 옵션 부가 정보',
+    constraint uq_item_option_value_info unique (option_type(10), option_sub_type(10), option_value(10), option_value2(20))
+)
+    comment '아이템 옵션 정보 테이블';
+
+-- 초기 데이터 적재 쿼리
+-- insert into item_option_value_info (option_type, option_sub_type, option_value, option_value2, option_desc) select distinct option_type, option_sub_type, option_value, option_value2, option_desc from auction_item_option;


### PR DESCRIPTION
## 📋 상세 설명

- 아이텝 옵션 값 정보 테이블 CREATE문을 flyway script 작성
```
create table item_option_value_info
(
    option_type      varchar(100) null comment '아이템 옵션 유형',
    option_sub_type  varchar(100) null comment '아이템 옵션 하위 유형',
    option_value     varchar(255) null comment '아이템 옵션 값',
    option_value2    varchar(255) null comment '아이템 옵션 값 2',
    option_desc      text         null comment '아이템 옵션 부가 정보',
    constraint uq_item_option_value_info unique (option_type(10), option_sub_type(10), option_value(10), option_value2(20))
)
    comment '아이템 옵션 정보 테이블';

-- 초기 데이터 적재 쿼리
-- insert into item_option_value_info (option_type, option_sub_type, option_value, option_value2, option_desc) select distinct option_type, option_sub_type, option_value, option_value2, option_desc from auction_item_option;
```
- 기본 조회 (findAll)을 위한 컨트롤러, 서비스, 레포지토리 클래스 구현

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

> Close #57 