### PR TITLE
feat: 경매장 거래 내역 INDEX 생성 및 조회 파라미터 우선순위 반영

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -39,11 +39,14 @@ class AuctionHistoryQueryDslRepository {
 
     private BooleanBuilder buildPredicate(AuctionHistorySearchRequest c, QAuctionHistory ah) {
         BooleanBuilder builder = new BooleanBuilder();
-        if (c.getItemName() != null && !c.getItemName().isBlank()) {
-            builder.and(ah.itemName.containsIgnoreCase(c.getItemName()));
+        if (c.getItemTopCategory() != null && !c.getItemTopCategory().isBlank()) {
+            builder.and(ah.itemTopCategory.eq(c.getItemTopCategory()));
         }
         if (c.getItemSubCategory() != null && !c.getItemSubCategory().isBlank()) {
             builder.and(ah.itemSubCategory.eq(c.getItemSubCategory()));
+        }
+        if (c.getItemName() != null && !c.getItemName().isBlank()) {
+            builder.and(ah.itemName.containsIgnoreCase(c.getItemName()));
         }
         return builder;
     }

--- a/src/main/resources/db/migration/V8__create_auction_history_index.sql
+++ b/src/main/resources/db/migration/V8__create_auction_history_index.sql
@@ -1,0 +1,2 @@
+create index idx_top_sub_item
+    on auction_history (item_top_category, item_sub_category, item_name);


### PR DESCRIPTION
## 📋 상세 설명
- auction history index flyway V8 script 작성
  - 아이템명이 있는 검색 시 top category, sub category, item_name 정보를 무조건 받음으로, index도 동일하게 생성
- index에 따른 auction history query dsl 변경

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

> Close #59 
