### PR TITLE
feat: 경매장 거래 내역 검색 조건 테이블 및 조회 API 구현

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,8 @@
 applicationVersion=0.0.1
 ### Project Config ###
 projectGroup=until.the.eternity
+### Gradle Configuration ###
+org.gradle.java.installations.auto-download=true
 ### Project Dependency Versions ###
 javaVersion=21
 ### Spring Dependency Versions ###

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -39,14 +39,14 @@ class AuctionHistoryQueryDslRepository {
 
     private BooleanBuilder buildPredicate(AuctionHistorySearchRequest c, QAuctionHistory ah) {
         BooleanBuilder builder = new BooleanBuilder();
-        if (c.getItemTopCategory() != null && !c.getItemTopCategory().isBlank()) {
-            builder.and(ah.itemTopCategory.eq(c.getItemTopCategory()));
+        if (c.itemTopCategory() != null && !c.itemTopCategory().isBlank()) {
+            builder.and(ah.itemTopCategory.eq(c.itemTopCategory()));
         }
-        if (c.getItemSubCategory() != null && !c.getItemSubCategory().isBlank()) {
-            builder.and(ah.itemSubCategory.eq(c.getItemSubCategory()));
+        if (c.itemSubCategory() != null && !c.itemSubCategory().isBlank()) {
+            builder.and(ah.itemSubCategory.eq(c.itemSubCategory()));
         }
-        if (c.getItemName() != null && !c.getItemName().isBlank()) {
-            builder.and(ah.itemName.containsIgnoreCase(c.getItemName()));
+        if (c.itemName() != null && !c.itemName().isBlank()) {
+            builder.and(ah.itemName.containsIgnoreCase(c.itemName()));
         }
         return builder;
     }

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -7,6 +7,6 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드") String itemName,
         @Schema(description = "대분류 카테고리", example = "근거리 장비") String itemTopCategory,
         @Schema(description = "소분류 카테고리", example = "검") String itemSubCategory,
+        // TODO: 거래 가격, 거래 일자를 범위 검색으로 변경, 옵션은 별도의 RequestDTO 구현git
         @Schema(description = "거래 가격", example = "10000000") String auction_price_per_unit,
-        @Schema(description = "거래 일자", example = "검") String date_auction_buy,
-        @Schema(description = "거래 금액") PriceSearchRequest priceSearchRequest) {}
+        @Schema(description = "거래 일자", example = "검") String date_auction_buy) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -9,4 +9,4 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "소분류 카테고리", example = "검") String itemSubCategory,
         @Schema(description = "거래 가격", example = "10000000") String auction_price_per_unit,
         @Schema(description = "거래 일자", example = "검") String date_auction_buy,
-        @Schema(description = "거래 금액") PricePerUnitSearchRequest pricePerUnitSearchRequest) {}
+        @Schema(description = "거래 금액") PriceSearchRequest priceSearchRequest) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -7,6 +7,6 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드") String itemName,
         @Schema(description = "대분류 카테고리", example = "근거리 장비") String itemTopCategory,
         @Schema(description = "소분류 카테고리", example = "검") String itemSubCategory,
-        // TODO: 거래 가격, 거래 일자를 범위 검색으로 변경, 옵션은 별도의 RequestDTO 구현git
+        // TODO: 거래 가격, 거래 일자를 범위 검색으로 변경, 옵션은 별도의 RequestDTO 구현
         @Schema(description = "거래 가격", example = "10000000") String auction_price_per_unit,
         @Schema(description = "거래 일자", example = "검") String date_auction_buy) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -1,23 +1,12 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
 
 /** 경매 히스토리 검색 조건 DTO - 페이지네이션 포함 */
-@Getter
-@Setter
-@ToString(callSuper = true)
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class AuctionHistorySearchRequest {
-
-    @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드")
-    private String itemName;
-
-    @Schema(description = "대분류 카테고리", example = "근거리 장비")
-    private String itemTopCategory;
-
-    @Schema(description = "소분류 카테고리", example = "검")
-    private String itemSubCategory;
-}
+public record AuctionHistorySearchRequest(
+        @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드") String itemName,
+        @Schema(description = "대분류 카테고리", example = "근거리 장비") String itemTopCategory,
+        @Schema(description = "소분류 카테고리", example = "검") String itemSubCategory,
+        @Schema(description = "거래 가격", example = "10000000") String auction_price_per_unit,
+        @Schema(description = "거래 일자", example = "검") String date_auction_buy,
+        @Schema(description = "거래 금액") PricePerUnitSearchRequest pricePerUnitSearchRequest) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PricePerUnitSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PricePerUnitSearchRequest.java
@@ -1,4 +1,8 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
 
-public record PricePerUnitSearchRequest() {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PricePerUnitSearchRequest(
+        @Schema(description = "가격 최소값", example = "0", defaultValue = "0") long PriceTo,
+        @Schema(description = "가격 최대값", example = "9999999999", defaultValue = "9999999999")
+                long PriceFrom) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PricePerUnitSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PricePerUnitSearchRequest.java
@@ -1,0 +1,4 @@
+package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
+
+public record PricePerUnitSearchRequest() {
+}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PriceSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/PriceSearchRequest.java
@@ -2,7 +2,7 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record PricePerUnitSearchRequest(
+public record PriceSearchRequest(
         @Schema(description = "가격 최소값", example = "0", defaultValue = "0") long PriceTo,
         @Schema(description = "가격 최대값", example = "9999999999", defaultValue = "9999999999")
                 long PriceFrom) {}

--- a/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
@@ -1,0 +1,56 @@
+package until.the.eternity.auctionsearchoption.application.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
+import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
+import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuctionSearchOptionService {
+
+    private final AuctionSearchOptionRepositoryPort repositoryPort;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 모든 활성화된 검색 옵션 조회
+     *
+     * @return 검색 옵션 메타데이터 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<SearchOptionMetadataResponse> getAllActiveSearchOptions() {
+        List<AuctionSearchOptionMetadata> entities = repositoryPort.findAllActive();
+
+        return entities.stream().map(this::toResponse).toList();
+    }
+
+    private SearchOptionMetadataResponse toResponse(AuctionSearchOptionMetadata entity) {
+        Map<String, FieldMetadata> searchCondition =
+                parseJsonToFieldMetadata(entity.getSearchConditionJson());
+
+        return new SearchOptionMetadataResponse(
+                entity.getId(),
+                entity.getSearchOptionName(),
+                searchCondition,
+                entity.getDisplayOrder());
+    }
+
+    private Map<String, FieldMetadata> parseJsonToFieldMetadata(String json) {
+        try {
+            TypeReference<Map<String, FieldMetadata>> typeRef = new TypeReference<>() {};
+            return objectMapper.readValue(json, typeRef);
+        } catch (Exception e) {
+            log.error("Failed to parse JSON to FieldMetadata: {}", json, e);
+            throw new IllegalStateException("JSON 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
@@ -1,0 +1,50 @@
+package until.the.eternity.auctionsearchoption.domain.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "auction_search_option_metadata")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuctionSearchOptionMetadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "search_option_name", nullable = false, length = 100)
+    private String searchOptionName;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "search_condition_json", nullable = false, columnDefinition = "JSON")
+    private String searchConditionJson;
+
+    @Column(name = "display_order", nullable = false, unique = true)
+    private Integer displayOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
@@ -1,0 +1,21 @@
+package until.the.eternity.auctionsearchoption.domain.repository;
+
+import java.util.List;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+public interface AuctionSearchOptionRepositoryPort {
+
+    /**
+     * 모든 활성화된 검색 옵션 조회 (정렬 순서대로)
+     *
+     * @return 검색 옵션 메타데이터 리스트
+     */
+    List<AuctionSearchOptionMetadata> findAllActive();
+
+    /**
+     * 모든 검색 옵션 조회 (정렬 순서대로)
+     *
+     * @return 검색 옵션 메타데이터 리스트
+     */
+    List<AuctionSearchOptionMetadata> findAll();
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
@@ -1,0 +1,15 @@
+package until.the.eternity.auctionsearchoption.infrastructure.persistence;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+@Repository
+interface AuctionSearchOptionJpaRepository
+        extends JpaRepository<AuctionSearchOptionMetadata, Long> {
+
+    List<AuctionSearchOptionMetadata> findByIsActiveTrueOrderByDisplayOrderAsc();
+
+    List<AuctionSearchOptionMetadata> findAllByOrderByDisplayOrderAsc();
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
@@ -1,0 +1,24 @@
+package until.the.eternity.auctionsearchoption.infrastructure.persistence;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
+
+@Component
+@RequiredArgsConstructor
+class AuctionSearchOptionRepositoryPortImpl implements AuctionSearchOptionRepositoryPort {
+
+    private final AuctionSearchOptionJpaRepository jpaRepository;
+
+    @Override
+    public List<AuctionSearchOptionMetadata> findAllActive() {
+        return jpaRepository.findByIsActiveTrueOrderByDisplayOrderAsc();
+    }
+
+    @Override
+    public List<AuctionSearchOptionMetadata> findAll() {
+        return jpaRepository.findAllByOrderByDisplayOrderAsc();
+    }
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
@@ -1,0 +1,31 @@
+package until.the.eternity.auctionsearchoption.interfaces.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.auctionsearchoption.application.service.AuctionSearchOptionService;
+import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
+import until.the.eternity.common.response.ApiResponse;
+
+@Tag(name = "Auction Search Option", description = "경매 검색 옵션 API")
+@RestController
+@RequestMapping("/api/search-option")
+@RequiredArgsConstructor
+public class AuctionSearchOptionController {
+
+    private final AuctionSearchOptionService service;
+
+    @Operation(summary = "검색 옵션 메타데이터 조회", description = "경매 검색에 사용 가능한 모든 옵션 메타데이터를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SearchOptionMetadataResponse>>> getSearchOptions() {
+        List<SearchOptionMetadataResponse> searchOptions = service.getAllActiveSearchOptions();
+
+        return ResponseEntity.ok(
+                ApiResponse.success("SEARCH_OPTION_SUCCESS", "검색 옵션 조회 성공", searchOptions));
+    }
+}

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
@@ -1,0 +1,13 @@
+package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "검색 조건 필드 메타데이터")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FieldMetadata(
+        @Schema(description = "필드 타입", example = "tinyint") String type,
+        @Schema(description = "필수 여부", example = "false") Boolean required,
+        @Schema(description = "허용된 값 목록 (Enum인 경우)", example = "[\"UP\", \"DOWN\"]")
+                List<String> allowedValues) {}

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
@@ -1,0 +1,11 @@
+package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(description = "검색 옵션 메타데이터 응답")
+public record SearchOptionMetadataResponse(
+        @Schema(description = "검색 옵션 ID", example = "1") Long id,
+        @Schema(description = "검색 옵션명", example = "밸런스") String searchOptionName,
+        @Schema(description = "검색 조건 상세") Map<String, FieldMetadata> searchCondition,
+        @Schema(description = "정렬 순서", example = "1") Integer displayOrder) {}

--- a/src/main/resources/db/migration/R__insert_auction_search_option_metadata.sql
+++ b/src/main/resources/db/migration/R__insert_auction_search_option_metadata.sql
@@ -1,0 +1,211 @@
+-- 경매 검색 옵션 메타데이터 초기 데이터
+-- Repeatable: 데이터 변경 시 자동 재실행
+
+-- 기존 데이터 삭제 (Repeatable 스크립트이므로)
+DELETE FROM `auction_search_option_metadata`;
+
+-- 1. 밸런스
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '밸런스',
+    JSON_OBJECT(
+        'Balance', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'BalanceStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    1,
+    true
+);
+
+-- 2. 크리티컬
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '크리티컬',
+    JSON_OBJECT(
+        'Critical', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'CriticalStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    2,
+    true
+);
+
+-- 3. 방어력
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '방어력',
+    JSON_OBJECT(
+        'Defense', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'DefenseStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    3,
+    true
+);
+
+-- 4. 에르그 (범위)
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '에르그',
+    JSON_OBJECT(
+        'ErgFrom', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'ErgTo', JSON_OBJECT('type', 'tinyint', 'required', false)
+    ),
+    4,
+    true
+);
+
+-- 5. 에르그 등급
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '에르그 등급',
+    JSON_OBJECT(
+        'ErgRank', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('S등급', 'A등급', 'B등급'), 'required', false)
+    ),
+    5,
+    true
+);
+
+-- 6. 마법 방어력
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '마법 방어력',
+    JSON_OBJECT(
+        'MagicDefense', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'MagicDefenseStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    6,
+    true
+);
+
+-- 7. 마법 보호
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '마법 보호',
+    JSON_OBJECT(
+        'MagicProtect', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'MagicProtectStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    7,
+    true
+);
+
+-- 8. 최대 공격력
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '최대 공격력',
+    JSON_OBJECT(
+        'MaxAttackFrom', JSON_OBJECT('type', 'int', 'required', false),
+        'MaxAttackTo', JSON_OBJECT('type', 'int', 'required', false)
+    ),
+    8,
+    true
+);
+
+-- 9. 최대 내구력
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '최대 내구력',
+    JSON_OBJECT(
+        'MaximumDurability', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'MaximumDurabilityStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    9,
+    true
+);
+
+-- 10. 최대 부상률
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '최대 부상률',
+    JSON_OBJECT(
+        'MaxInjuryRateFrom', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'MaxInjuryRateTo', JSON_OBJECT('type', 'tinyint', 'required', false)
+    ),
+    10,
+    true
+);
+
+-- 11. 숙련도
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '숙련도',
+    JSON_OBJECT(
+        'Proficiency', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'ProficiencyStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    11,
+    true
+);
+
+-- 12. 보호
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '보호',
+    JSON_OBJECT(
+        'Protect', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'ProtectStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    12,
+    true
+);
+
+-- 13. 남은 거래 횟수
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '남은 거래 횟수',
+    JSON_OBJECT(
+        'RemainingTransactionCount', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'RemainingTransactionCountStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    13,
+    true
+);
+
+-- 14. 남은 전용 해제 가능 횟수
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '남은 전용 해제 가능 횟수',
+    JSON_OBJECT(
+        'RemainingUnsealCount', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'RemainingUnsealCountStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    14,
+    true
+);
+
+-- 15. 남은 사용 횟수
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '남은 사용 횟수',
+    JSON_OBJECT(
+        'RemainingUseCount', JSON_OBJECT('type', 'tinyint', 'required', false),
+        'RemainingUseCountStandard', JSON_OBJECT('type', 'string', 'allowedValues', JSON_ARRAY('UP', 'DOWN'), 'required', false)
+    ),
+    15,
+    true
+);
+
+-- 16. 착용 제한
+INSERT INTO `auction_search_option_metadata`
+(`search_option_name`, `search_condition_json`, `display_order`, `is_active`)
+VALUES (
+    '착용 제한',
+    JSON_OBJECT(
+        'WearingRestrictions', JSON_OBJECT('type', 'string', 'required', false)
+    ),
+    16,
+    true
+);

--- a/src/main/resources/db/migration/V11__create_auction_search_option_metadata.sql
+++ b/src/main/resources/db/migration/V11__create_auction_search_option_metadata.sql
@@ -1,0 +1,13 @@
+-- 경매 검색 옵션 메타데이터 테이블 생성
+CREATE TABLE `auction_search_option_metadata` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `search_option_name` VARCHAR(100) NOT NULL COMMENT '검색 옵션명 (한글)',
+    `search_condition_json` JSON NOT NULL COMMENT '검색 조건 (파라미터명:타입)',
+    `display_order` INT NOT NULL UNIQUE COMMENT '정렬 순서 (고유값)',
+    `is_active` BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성화 여부',
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (`id`),
+    INDEX `idx_display_order` (`display_order`),
+    INDEX `idx_is_active` (`is_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='경매 검색 옵션 메타데이터';

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -42,7 +42,7 @@ class AuctionHistoryServiceTest {
     void search_should_return_paged_response() {
         // given
         AuctionHistorySearchRequest searchRequest =
-                new AuctionHistorySearchRequest(null, null, null, null, null, null);
+                new AuctionHistorySearchRequest(null, null, null, null, null);
         PageRequestDto pageRequestDto = mock(PageRequestDto.class);
         Pageable pageable = PageRequest.of(0, 10);
         when(pageRequestDto.toPageable()).thenReturn(pageable);

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -41,7 +41,8 @@ class AuctionHistoryServiceTest {
     @DisplayName("검색은 무조건 페이지를 반환한다")
     void search_should_return_paged_response() {
         // given
-        AuctionHistorySearchRequest searchRequest = new AuctionHistorySearchRequest();
+        AuctionHistorySearchRequest searchRequest =
+                new AuctionHistorySearchRequest(null, null, null, null, null, null);
         PageRequestDto pageRequestDto = mock(PageRequestDto.class);
         Pageable pageable = PageRequest.of(0, 10);
         when(pageRequestDto.toPageable()).thenReturn(pageable);

--- a/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
@@ -1,0 +1,144 @@
+package until.the.eternity.auctionsearchoption.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
+import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
+import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionSearchOptionServiceTest {
+
+    @Mock private AuctionSearchOptionRepositoryPort repositoryPort;
+    @Mock private ObjectMapper objectMapper;
+
+    @InjectMocks private AuctionSearchOptionService service;
+
+    @Test
+    @DisplayName("모든 활성화된 검색 옵션을 조회하면 응답 리스트를 반환한다")
+    void getAllActiveSearchOptions_should_return_response_list() throws Exception {
+        // given
+        AuctionSearchOptionMetadata entity1 =
+                createEntity(1L, "밸런스", "{\"balance\":{\"type\":\"tinyint\"}}", 1);
+        AuctionSearchOptionMetadata entity2 =
+                createEntity(2L, "공격력", "{\"attack\":{\"type\":\"int\"}}", 2);
+        Map<String, FieldMetadata> fieldMetadataMap =
+                Map.of("balance", new FieldMetadata("tinyint", false, null));
+
+        when(repositoryPort.findAllActive()).thenReturn(List.of(entity1, entity2));
+        when(objectMapper.readValue(
+                        anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(fieldMetadataMap);
+
+        // when
+        List<SearchOptionMetadataResponse> result = service.getAllActiveSearchOptions();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).searchOptionName()).isEqualTo("밸런스");
+        assertThat(result.get(1).searchOptionName()).isEqualTo("공격력");
+        assertThat(result.get(0).displayOrder()).isEqualTo(1);
+        assertThat(result.get(1).displayOrder()).isEqualTo(2);
+
+        verify(repositoryPort).findAllActive();
+        verify(objectMapper, times(2))
+                .readValue(anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    @DisplayName("활성화된 검색 옵션이 없으면 빈 리스트를 반환한다")
+    void getAllActiveSearchOptions_should_return_empty_list_when_no_active_options() {
+        // given
+        when(repositoryPort.findAllActive()).thenReturn(List.of());
+
+        // when
+        List<SearchOptionMetadataResponse> result = service.getAllActiveSearchOptions();
+
+        // then
+        assertThat(result).isEmpty();
+        verify(repositoryPort).findAllActive();
+        verifyNoInteractions(objectMapper);
+    }
+
+    @Test
+    @DisplayName("검색 조건 JSON을 올바르게 파싱하여 응답에 포함한다")
+    void getAllActiveSearchOptions_should_parse_json_correctly() throws Exception {
+        // given
+        AuctionSearchOptionMetadata entity1 =
+                createEntity(1L, "밸런스", "{\"balance\":{\"type\":\"tinyint\"}}", 1);
+        FieldMetadata balanceField = new FieldMetadata("tinyint", false, null);
+        Map<String, FieldMetadata> parsedMap = Map.of("balance", balanceField);
+
+        when(repositoryPort.findAllActive()).thenReturn(List.of(entity1));
+        when(objectMapper.readValue(
+                        eq(entity1.getSearchConditionJson()),
+                        any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(parsedMap);
+
+        // when
+        List<SearchOptionMetadataResponse> result = service.getAllActiveSearchOptions();
+
+        // then
+        assertThat(result).hasSize(1);
+        SearchOptionMetadataResponse response = result.get(0);
+        assertThat(response.searchCondition()).containsKey("balance");
+        assertThat(response.searchCondition().get("balance")).isEqualTo(balanceField);
+
+        verify(objectMapper)
+                .readValue(
+                        eq(entity1.getSearchConditionJson()),
+                        any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    @DisplayName("응답은 display_order 순서대로 정렬되어 있다")
+    void getAllActiveSearchOptions_should_maintain_display_order() throws Exception {
+        // given
+        AuctionSearchOptionMetadata entity1 =
+                createEntity(1L, "밸런스", "{\"balance\":{\"type\":\"tinyint\"}}", 1);
+        AuctionSearchOptionMetadata entity2 =
+                createEntity(2L, "공격력", "{\"attack\":{\"type\":\"int\"}}", 2);
+        AuctionSearchOptionMetadata entity3 =
+                createEntity(3L, "크리티컬", "{\"critical\":{\"type\":\"int\"}}", 3);
+        Map<String, FieldMetadata> fieldMetadataMap =
+                Map.of("balance", new FieldMetadata("tinyint", false, null));
+
+        when(repositoryPort.findAllActive()).thenReturn(List.of(entity1, entity2, entity3));
+        when(objectMapper.readValue(
+                        anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(fieldMetadataMap);
+
+        // when
+        List<SearchOptionMetadataResponse> result = service.getAllActiveSearchOptions();
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).displayOrder()).isEqualTo(1);
+        assertThat(result.get(1).displayOrder()).isEqualTo(2);
+        assertThat(result.get(2).displayOrder()).isEqualTo(3);
+        assertThat(result).extracting("searchOptionName").containsExactly("밸런스", "공격력", "크리티컬");
+    }
+
+    private AuctionSearchOptionMetadata createEntity(
+            Long id, String searchOptionName, String searchConditionJson, Integer displayOrder) {
+        AuctionSearchOptionMetadata entity = mock(AuctionSearchOptionMetadata.class);
+
+        when(entity.getId()).thenReturn(id);
+        when(entity.getSearchOptionName()).thenReturn(searchOptionName);
+        when(entity.getSearchConditionJson()).thenReturn(searchConditionJson);
+        when(entity.getDisplayOrder()).thenReturn(displayOrder);
+
+        return entity;
+    }
+}


### PR DESCRIPTION
## 📋 상세 설명

- 클라이언트에서 경매작 검색 내역 검색 조건 뷰를 렌더링할 수 있도록, 검색 조건 조회 API 구현
- flyway script로 검색 조건 데이터 테이블  `auction_search_option_metadata` 생성 및 초기 데이터 적재
- 테스트 코드 작성

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #68 