### PR TITLE
feat: 가격 랭킹 API 구현

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,9 +15,6 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.event.AuctionHistorySavedEvent;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.application.service;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,8 +15,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,5 +1,8 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -8,10 +11,6 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.OptionalInt;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,5 +1,6 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,8 +10,6 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
-
 import java.time.Instant;
 import java.util.List;
+import lombok.*;
+import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
 
 @Entity
 @Table(name = "auction_history")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
@@ -1,8 +1,7 @@
 package until.the.eternity.auctionhistory.domain.event;
 
-import lombok.Getter;
-
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 /** 경매장 거래 내역 저장 완료 이벤트 AuctionHistoryScheduler가 거래 내역을 성공적으로 저장한 후 발행됩니다. */
 @Getter

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
-
-import java.util.List;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiItemOptionMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiItemOptionMapper.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Mapper(componentModel = "spring")
 public interface OpenApiItemOptionMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,15 +1,14 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,5 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -7,11 +11,6 @@ import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryReposit
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort.LatestDateWithIds;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalInt;
-import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,9 +1,8 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
+import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,15 +1,14 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -8,6 +8,11 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -22,12 +27,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.request.DateAuction
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
 import until.the.eternity.auctionitemoption.domain.entity.QAuctionHistoryItemOption;
-
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,6 +1,10 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -11,11 +15,6 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,10 +2,9 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
-
 import java.time.Instant;
 import java.util.List;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
@@ -3,7 +3,6 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Arrays;
 
 /** 검색 기준 (이상/이하/같음) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
@@ -3,7 +3,6 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Arrays;
 
 /** 정렬 방향 (오름차순/내림차순) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.Instant;
 import java.util.List;
+import lombok.*;
 
 /** 실시간 경매장에서 판매 중인 아이템 정보. V15 마이그레이션에서 auction_item → auction_realtime_item으로 변경됨. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
@@ -1,12 +1,11 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 /** 실시간 경매장 아이템(auction_realtime_item)에 연결된 아이템 옵션 정보. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionitemoption.domain.entity;
 
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
-
-import java.util.UUID;
 
 /**
  * 경매장 거래 내역(auction_history)에 연결된 아이템 옵션 정보. V15 마이그레이션에서 auction_item_option →

--- a/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
@@ -1,5 +1,8 @@
 package until.the.eternity.auctionrealtime.application.scheduler;
 
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,10 +14,6 @@ import until.the.eternity.auctionrealtime.application.service.fetcher.AuctionRea
 import until.the.eternity.auctionrealtime.application.service.persister.AuctionRealtimePersister;
 import until.the.eternity.auctionrealtime.domain.service.fetcher.AuctionRealtimeFetcherPort.FetchResult;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * 실시간 경매장 데이터 수집 스케줄러.

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionrealtime.application.service;
 
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,9 +16,6 @@ import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.AuctionRe
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeItemOptionResponse;
 import until.the.eternity.common.enums.ItemCategory;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.time.Instant;
-import java.util.List;
 
 /** 실시간 경매장 데이터 Service. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
@@ -1,5 +1,8 @@
 package until.the.eternity.auctionrealtime.application.service.fetcher;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,10 +13,6 @@ import until.the.eternity.auctionrealtime.infrastructure.client.AuctionRealtimeC
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeListResponse;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 /** 실시간 경매장 데이터 Fetcher 구현체. Cursor 기반 페이징으로 API를 호출하고, 중복 감지 시 호출을 중단한다. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
@@ -1,5 +1,7 @@
 package until.the.eternity.auctionrealtime.application.service.persister;
 
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,9 +11,6 @@ import until.the.eternity.auctionrealtime.domain.service.AuctionRealtimeDuplicat
 import until.the.eternity.auctionrealtime.domain.service.persister.AuctionRealtimePersisterPort;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 /** 실시간 경매장 데이터 Persister 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.AuctionRealtimeDetailResponse;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeItemOptionResponse;
-
-import java.util.List;
 
 /** AuctionRealtimeItem Entity to DTO mapper class. */
 @Mapper(componentModel = "spring")

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 
 /** OpenApiAuctionRealtimeResponse → AuctionRealtimeItem Entity 변환 Mapper. */
 @Mapper(componentModel = "spring", uses = OpenApiRealtimeItemOptionMapper.class)

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiRealtimeItemOptionMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiRealtimeItemOptionMapper.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItemOption;
 import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** OpenApiAuctionItemOptionResponse → AuctionRealtimeItemOption Entity 변환 Mapper. */
 @Mapper(componentModel = "spring")

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
@@ -1,14 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.repository;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** AuctionRealtimeItem Repository Port (Hexagonal Architecture). */
 public interface AuctionRealtimeItemRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/AuctionRealtimeDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/AuctionRealtimeDuplicateChecker.java
@@ -1,15 +1,14 @@
 package until.the.eternity.auctionrealtime.domain.service;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionrealtime.domain.repository.AuctionRealtimeItemRepositoryPort;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * 실시간 경매장 데이터의 중복 체크 로직.

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionrealtime.domain.service.fetcher;
 
-import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
-import until.the.eternity.common.enums.ItemCategory;
-
 import java.time.Instant;
 import java.util.List;
+import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
+import until.the.eternity.common.enums.ItemCategory;
 
 /** 실시간 경매장 데이터 Fetcher Port. */
 public interface AuctionRealtimeFetcherPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionrealtime.domain.service.persister;
 
+import java.time.Instant;
+import java.util.List;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
 
 /** 실시간 경매장 데이터 Persister Port. */
 public interface AuctionRealtimePersisterPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
+import java.time.Instant;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
-
-import java.time.Instant;
-import java.util.Optional;
 
 /** AuctionRealtimeItem JPA Repository. */
 public interface AuctionRealtimeItemRepository extends JpaRepository<AuctionRealtimeItem, Long> {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
@@ -1,6 +1,9 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -10,10 +13,6 @@ import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.domain.repository.AuctionRealtimeItemRepositoryPort;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 /** AuctionRealtimeItemRepositoryPort 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -8,6 +8,8 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,9 +23,6 @@ import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 /** Nexon Open API /auction/list 응답 리스트 DTO. */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
@@ -2,10 +2,9 @@ package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
-
 import java.time.Instant;
 import java.util.List;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 /** Nexon Open API /auction/list 응답 DTO. 현재 경매장에서 판매 중인 아이템 정보. */
 public record OpenApiAuctionRealtimeResponse(

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
@@ -3,7 +3,6 @@ package until.the.eternity.auctionrealtime.interfaces.rest.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Arrays;
 
 /** 실시간 경매장 정렬 필드 */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
@@ -2,6 +2,8 @@ package until.the.eternity.auctionsearchoption.application.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,9 +12,6 @@ import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionM
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
-
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
@@ -1,13 +1,12 @@
 package until.the.eternity.auctionsearchoption.domain.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "auction_search_option_metadata")

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
@@ -1,8 +1,7 @@
 package until.the.eternity.auctionsearchoption.domain.repository;
 
-import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
-
 import java.util.List;
+import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
 
 public interface AuctionSearchOptionRepositoryPort {
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
@@ -1,10 +1,9 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
-
-import java.util.List;
 
 @Repository
 interface AuctionSearchOptionJpaRepository

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
@@ -1,11 +1,10 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
@@ -2,6 +2,7 @@ package until.the.eternity.auctionsearchoption.interfaces.rest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,8 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.auctionsearchoption.application.service.AuctionSearchOptionService;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
 import until.the.eternity.common.response.ApiResponse;
-
-import java.util.List;
 
 @Tag(name = "Auction Search Option", description = "경매 검색 옵션 API")
 @RestController

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
@@ -2,7 +2,6 @@ package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "검색 조건 필드 메타데이터")

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Map;
 
 @Schema(description = "검색 옵션 메타데이터 응답")

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,12 +1,11 @@
 package until.the.eternity.common.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/common/enums/SortDirection.java
@@ -3,9 +3,8 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.data.domain.Sort;
-
 import java.util.Arrays;
+import org.springframework.data.domain.Sort;
 
 /** 정렬 방향 (오름차순/내림차순) */
 @Schema(description = "정렬 방향", enumAsRef = true)

--- a/src/main/java/until/the/eternity/common/enums/SortField.java
+++ b/src/main/java/until/the/eternity/common/enums/SortField.java
@@ -3,7 +3,6 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Arrays;
 
 /** 정렬 필드 */

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
-
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
+++ b/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
@@ -4,6 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +18,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import until.the.eternity.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.common.util.IpAddressUtil;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Gateway에서 전달한 인증 헤더(X-Auth-*)를 기반으로 Spring Security의 Authentication을 생성하는 필터

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,9 +1,8 @@
 package until.the.eternity.common.response;
 
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,7 +1,6 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,12 +1,11 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
-
-import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,11 +1,10 @@
 package until.the.eternity.config.openapi;
 
+import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
-
-import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,10 +2,9 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
-
-import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
@@ -1,5 +1,6 @@
 package until.the.eternity.hornBugle.application.runner;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -12,8 +13,6 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexService;
-
-import java.util.List;
 
 /**
  * 서버 재기동 시 DB 데이터를 Elasticsearch에 일괄 색인하는 Runner. application.yml에서

--- a/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
@@ -1,5 +1,7 @@
 package until.the.eternity.hornBugle.application.scheduler;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,9 +12,6 @@ import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.infrastructure.client.HornBugleClient;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryListResponse;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
@@ -1,5 +1,8 @@
 package until.the.eternity.hornBugle.application.service;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -15,10 +18,6 @@ import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexS
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -154,7 +153,9 @@ public class HornBugleService {
         return PageResponseDto.of(responsePage);
     }
 
-    /** MySQL FULLTEXT 검색으로 keyword 검색을 수행한다. Native Query에서 ORDER BY를 지정하므로 Sort 없이 Pageable을 전달한다. */
+    /**
+     * MySQL FULLTEXT 검색으로 keyword 검색을 수행한다. Native Query에서 ORDER BY를 지정하므로 Sort 없이 Pageable을 전달한다.
+     */
     private PageResponseDto<HornBugleHistoryResponse> searchByDatabaseWithKeyword(
             String serverName, String keyword, HornBuglePageRequestDto pageRequest) {
 

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,9 +1,8 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.Instant;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
@@ -1,11 +1,10 @@
 package until.the.eternity.hornBugle.domain.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
@@ -1,5 +1,6 @@
 package until.the.eternity.hornBugle.domain.mapper;
 
+import java.time.Instant;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
@@ -7,8 +8,6 @@ import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleDocument;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
-
-import java.time.Instant;
 
 @Mapper(componentModel = "spring")
 public interface HornBugleMapper {

--- a/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
@@ -1,12 +1,11 @@
 package until.the.eternity.hornBugle.domain.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 
 public interface HornBugleRepositoryPort {
 

--- a/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
@@ -1,5 +1,10 @@
 package until.the.eternity.hornBugle.domain.service;
 
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -7,12 +12,6 @@ import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
-
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
@@ -1,5 +1,6 @@
 package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,8 +11,6 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
-
-import java.time.Instant;
 
 @Document(indexName = "horn_bugle_world_history")
 @Setting(settingPath = "elasticsearch/horn-bugle-settings.json")

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,8 +17,6 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Service;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
-
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
@@ -1,15 +1,14 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface HornBugleJpaRepository extends JpaRepository<HornBugleWorldHistory, Long> {

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
@@ -1,6 +1,9 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -9,10 +12,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
@@ -1,7 +1,6 @@
 package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record OpenApiHornBugleHistoryListResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.Instant;
 
 public record OpenApiHornBugleHistoryResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/request/HornBuglePageRequestDto.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/request/HornBuglePageRequestDto.java
@@ -25,9 +25,7 @@ public record HornBuglePageRequestDto(
                 resolvedPage, resolvedSize, Sort.by(Sort.Direction.DESC, SORT_BY_DATE_SEND));
     }
 
-    /**
-     * Native Query용 Pageable (정렬 없음). Native Query에서 ORDER BY를 직접 지정하므로 Sort를 제외한다.
-     */
+    /** Native Query용 Pageable (정렬 없음). Native Query에서 ORDER BY를 직접 지정하므로 Sort를 제외한다. */
     public Pageable toPageableWithoutSort() {
         int resolvedPage = this.page != null ? this.page - 1 : DEFAULT_PAGE - 1;
         int resolvedSize = this.size != null ? this.size : DEFAULT_SIZE;

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.hornBugle.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.Instant;
 
 @Schema(description = "뿔피리 히스토리 응답")

--- a/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
+++ b/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
@@ -1,5 +1,9 @@
 package until.the.eternity.iteminfo.application.service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -17,11 +21,6 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
@@ -2,9 +2,8 @@ package until.the.eternity.iteminfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.*;
-
 import java.io.Serializable;
+import lombok.*;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
@@ -1,11 +1,11 @@
 package until.the.eternity.iteminfo.domain.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import until.the.eternity.common.exception.ExceptionCode;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
@@ -1,12 +1,11 @@
 package until.the.eternity.iteminfo.domain.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
-
-import java.util.List;
 
 public interface ItemInfoRepositoryPort {
     List<ItemInfo> findAll();

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
@@ -1,12 +1,11 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
-
-import java.util.List;
 
 public interface ItemInfoJpaRepository
         extends JpaRepository<ItemInfo, ItemInfoId>, JpaSpecificationExecutor<ItemInfo> {

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
@@ -3,6 +3,7 @@ package until.the.eternity.iteminfo.infrastructure.persistence;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -11,8 +12,6 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.QItemInfo;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
@@ -1,5 +1,6 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,8 +9,6 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -17,8 +18,6 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/item-infos")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
@@ -1,12 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-import until.the.eternity.common.enums.ItemCategory;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import until.the.eternity.common.enums.ItemCategory;
 
 @Getter
 @Builder

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
@@ -1,11 +1,10 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import until.the.eternity.iteminfo.domain.entity.ItemInfo;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 
 @Builder
 @Schema(description = "아이템 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
@@ -1,11 +1,10 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import until.the.eternity.iteminfo.domain.entity.ItemInfo;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 
 @Builder
 @Schema(description = "아이템 정보 요약 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
@@ -1,9 +1,8 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 @Schema(description = "아이템 정보 동기화 응답 DTO")

--- a/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
@@ -1,12 +1,12 @@
 package until.the.eternity.itemoptioninfo.application.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +17,32 @@ public class ItemOptionInfoService {
 
     public List<ItemOptionInfo> findAll() {
         return itemOptionInfoRepositoryPort.findAll();
+    }
+
+    public ItemOptionInfo findById(ItemOptionInfoId id) {
+        return itemOptionInfoRepositoryPort
+                .findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("아이템 옵션 정보를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public ItemOptionInfo create(ItemOptionInfo itemOptionInfo) {
+        if (itemOptionInfoRepositoryPort.existsById(itemOptionInfo.getId())) {
+            throw new IllegalArgumentException("이미 존재하는 아이템 옵션 정보입니다.");
+        }
+        return itemOptionInfoRepositoryPort.save(itemOptionInfo);
+    }
+
+    @Transactional
+    public ItemOptionInfo update(ItemOptionInfoId id, String optionDesc) {
+        ItemOptionInfo itemOptionInfo = findById(id);
+        itemOptionInfo.updateOptionDesc(optionDesc);
+        return itemOptionInfoRepositoryPort.save(itemOptionInfo);
+    }
+
+    @Transactional
+    public void delete(ItemOptionInfoId id) {
+        ItemOptionInfo itemOptionInfo = findById(id);
+        itemOptionInfoRepositoryPort.delete(itemOptionInfo);
     }
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfo.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfo.java
@@ -18,4 +18,13 @@ public class ItemOptionInfo {
 
     @Column(name = "option_desc", columnDefinition = "text")
     private String optionDesc;
+
+    public ItemOptionInfo(ItemOptionInfoId id, String optionDesc) {
+        this.id = id;
+        this.optionDesc = optionDesc;
+    }
+
+    public void updateOptionDesc(String optionDesc) {
+        this.optionDesc = optionDesc;
+    }
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
@@ -2,12 +2,11 @@ package until.the.eternity.itemoptioninfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-import java.util.Objects;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/mapper/ItemOptionInfoMapper.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/mapper/ItemOptionInfoMapper.java
@@ -2,6 +2,8 @@ package until.the.eternity.itemoptioninfo.domain.mapper;
 
 import org.springframework.stereotype.Component;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
+import until.the.eternity.itemoptioninfo.interfaces.rest.dto.request.ItemOptionInfoRequest;
 import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
 
 @Component
@@ -15,5 +17,23 @@ public class ItemOptionInfoMapper {
                 .optionValue2(itemOptionInfo.getId().getOptionValue2())
                 .optionDesc(itemOptionInfo.getOptionDesc())
                 .build();
+    }
+
+    public ItemOptionInfo toEntity(ItemOptionInfoRequest request) {
+        ItemOptionInfoId id =
+                new ItemOptionInfoId(
+                        request.getOptionType(),
+                        request.getOptionSubType(),
+                        request.getOptionValue(),
+                        request.getOptionValue2());
+        return new ItemOptionInfo(id, request.getOptionDesc());
+    }
+
+    public ItemOptionInfoId toId(ItemOptionInfoRequest request) {
+        return new ItemOptionInfoId(
+                request.getOptionType(),
+                request.getOptionSubType(),
+                request.getOptionValue(),
+                request.getOptionValue2());
     }
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
@@ -1,9 +1,18 @@
 package until.the.eternity.itemoptioninfo.domain.repository;
 
-import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
-
 import java.util.List;
+import java.util.Optional;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 
 public interface ItemOptionInfoRepositoryPort {
     List<ItemOptionInfo> findAll();
+
+    Optional<ItemOptionInfo> findById(ItemOptionInfoId id);
+
+    ItemOptionInfo save(ItemOptionInfo itemOptionInfo);
+
+    void delete(ItemOptionInfo itemOptionInfo);
+
+    boolean existsById(ItemOptionInfoId id);
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
@@ -1,11 +1,12 @@
 package until.the.eternity.itemoptioninfo.infrastructure.persistence;
 
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,5 +17,25 @@ public class ItemOptionInfoRepositoryPortImpl implements ItemOptionInfoRepositor
     @Override
     public List<ItemOptionInfo> findAll() {
         return itemOptionInfoJpaRepository.findAll();
+    }
+
+    @Override
+    public Optional<ItemOptionInfo> findById(ItemOptionInfoId id) {
+        return itemOptionInfoJpaRepository.findById(id);
+    }
+
+    @Override
+    public ItemOptionInfo save(ItemOptionInfo itemOptionInfo) {
+        return itemOptionInfoJpaRepository.save(itemOptionInfo);
+    }
+
+    @Override
+    public void delete(ItemOptionInfo itemOptionInfo) {
+        itemOptionInfoJpaRepository.delete(itemOptionInfo);
+    }
+
+    @Override
+    public boolean existsById(ItemOptionInfoId id) {
+        return itemOptionInfoJpaRepository.existsById(id);
     }
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
@@ -2,16 +2,25 @@ package until.the.eternity.itemoptioninfo.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import until.the.eternity.itemoptioninfo.application.service.ItemOptionInfoService;
-import until.the.eternity.itemoptioninfo.domain.mapper.ItemOptionInfoMapper;
-import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
-
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.itemoptioninfo.application.service.ItemOptionInfoService;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
+import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
+import until.the.eternity.itemoptioninfo.domain.mapper.ItemOptionInfoMapper;
+import until.the.eternity.itemoptioninfo.interfaces.rest.dto.request.ItemOptionInfoRequest;
+import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
 
 @RestController
 @RequestMapping("/api/v1/item-option-infos")
@@ -28,5 +37,36 @@ public class ItemOptionInfoController {
         return itemOptionInfoService.findAll().stream()
                 .map(itemOptionInfoMapper::toItemOptionInfoResponse)
                 .collect(Collectors.toList());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "아이템 옵션 정보 생성", description = "새로운 아이템 옵션 정보를 생성합니다.")
+    public ItemOptionInfoResponse create(@Valid @RequestBody ItemOptionInfoRequest request) {
+        ItemOptionInfo itemOptionInfo = itemOptionInfoMapper.toEntity(request);
+        ItemOptionInfo saved = itemOptionInfoService.create(itemOptionInfo);
+        return itemOptionInfoMapper.toItemOptionInfoResponse(saved);
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "아이템 옵션 정보 수정",
+            description =
+                    "아이템 옵션 정보를 수정합니다. 복합 키(optionType, optionSubType, optionValue, optionValue2)로 식별하며, optionDesc만 수정 가능합니다.")
+    public ItemOptionInfoResponse update(@Valid @RequestBody ItemOptionInfoRequest request) {
+        ItemOptionInfoId id = itemOptionInfoMapper.toId(request);
+        ItemOptionInfo updated = itemOptionInfoService.update(id, request.getOptionDesc());
+        return itemOptionInfoMapper.toItemOptionInfoResponse(updated);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+            summary = "아이템 옵션 정보 삭제",
+            description =
+                    "아이템 옵션 정보를 삭제합니다. 복합 키(optionType, optionSubType, optionValue, optionValue2)로 식별합니다.")
+    public void delete(@Valid @RequestBody ItemOptionInfoRequest request) {
+        ItemOptionInfoId id = itemOptionInfoMapper.toId(request);
+        itemOptionInfoService.delete(id);
     }
 }

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/dto/request/ItemOptionInfoRequest.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/dto/request/ItemOptionInfoRequest.java
@@ -1,0 +1,27 @@
+package until.the.eternity.itemoptioninfo.interfaces.rest.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ItemOptionInfoRequest {
+
+    @Schema(description = "아이템 옵션 유형", example = "STR")
+    @NotBlank(message = "옵션 유형은 필수입니다.")
+    private String optionType;
+
+    @Schema(description = "아이템 옵션 하위 유형", example = "+")
+    @NotBlank(message = "옵션 하위 유형은 필수입니다.")
+    private String optionSubType;
+
+    @Schema(description = "아이템 옵션 값", example = "10")
+    @NotBlank(message = "옵션 값은 필수입니다.")
+    private String optionValue;
+
+    @Schema(description = "아이템 옵션 값 2", example = "10%")
+    private String optionValue2;
+
+    @Schema(description = "아이템 옵션 부가 정보", example = "힘이 10 증가합니다.")
+    private String optionDesc;
+}

--- a/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
@@ -1,12 +1,11 @@
 package until.the.eternity.metalwareinfo.application.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
@@ -1,9 +1,8 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface MetalwareInfoJpaRepository extends JpaRepository<MetalwareInfoEntity, String> {
 

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
@@ -1,10 +1,9 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
@@ -2,14 +2,13 @@ package until.the.eternity.metalwareinfo.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.metalwareinfo.application.service.MetalwareInfoService;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/metalware-infos")

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
@@ -1,10 +1,9 @@
 package until.the.eternity.metalwareinfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
 
 @Builder
 @Schema(description = "세공 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
@@ -1,0 +1,30 @@
+package until.the.eternity.ranking.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.ranking.domain.mapper.RankingMapper;
+import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
+import until.the.eternity.ranking.repository.RankingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AllTimeRankingService {
+
+    private final RankingRepository rankingRepository;
+    private final RankingMapper rankingMapper;
+
+    /** 역대 최고가 거래 TOP N (API 11) */
+    public List<AllTimeRankingResponse> getAllTimeHighestPrice(int limit) {
+        List<Object[]> results = rankingRepository.findAllTimeHighestPrice(limit);
+        return rankingMapper.toAllTimeRankingResponses(results);
+    }
+
+    /** 이번 달 최대 거래액 TOP N (API 12) */
+    public List<AllTimeRankingResponse> getMonthLargestVolume(int limit) {
+        List<Object[]> results = rankingRepository.findMonthLargestVolume(limit);
+        return rankingMapper.toAllTimeRankingResponses(results);
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
@@ -1,0 +1,35 @@
+package until.the.eternity.ranking.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.ranking.domain.mapper.RankingMapper;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+import until.the.eternity.ranking.repository.RankingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryRankingService {
+
+    private final RankingRepository rankingRepository;
+    private final RankingMapper rankingMapper;
+
+    /** 카테고리별 최고가 TOP N (API 9) */
+    public List<PriceRankingResponse> getCategoryTopPriced(
+            String topCategory, String subCategory, int limit) {
+        List<Object[]> results =
+                rankingRepository.findCategoryTopPriced(topCategory, subCategory, limit);
+        return rankingMapper.toPriceRankingResponses(results);
+    }
+
+    /** 카테고리별 인기 아이템 TOP N (API 10) */
+    public List<VolumeRankingResponse> getCategoryPopular(
+            String topCategory, String subCategory, int limit) {
+        List<Object[]> results =
+                rankingRepository.findCategoryPopular(topCategory, subCategory, limit);
+        return rankingMapper.toVolumeRankingResponses(results);
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
@@ -1,0 +1,37 @@
+package until.the.eternity.ranking.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.ranking.domain.mapper.RankingMapper;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
+import until.the.eternity.ranking.repository.RankingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceChangeRankingService {
+
+    private final RankingRepository rankingRepository;
+    private final RankingMapper rankingMapper;
+
+    /** 가격 급등 TOP N (API 6) */
+    public List<PriceChangeRankingResponse> getPriceSurge(int limit) {
+        List<Object[]> results = rankingRepository.findPriceSurge(limit);
+        return rankingMapper.toPriceChangeRankingResponses(results);
+    }
+
+    /** 가격 급락 TOP N (API 7) */
+    public List<PriceChangeRankingResponse> getPriceDrop(int limit) {
+        List<Object[]> results = rankingRepository.findPriceDrop(limit);
+        return rankingMapper.toPriceChangeRankingResponses(results);
+    }
+
+    /** 거래량 급증 TOP N (API 8) */
+    public List<VolumeChangeRankingResponse> getVolumeSurge(int limit) {
+        List<Object[]> results = rankingRepository.findVolumeSurge(limit);
+        return rankingMapper.toVolumeChangeRankingResponses(results);
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
@@ -1,0 +1,36 @@
+package until.the.eternity.ranking.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.ranking.domain.mapper.RankingMapper;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+import until.the.eternity.ranking.repository.RankingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceRankingService {
+
+    private final RankingRepository rankingRepository;
+    private final RankingMapper rankingMapper;
+
+    /** 오늘의 최고가 거래 TOP N (API 1) */
+    public List<PriceRankingResponse> getTodayHighestPrice(int limit) {
+        List<Object[]> results = rankingRepository.findTodayHighestPrice(limit);
+        return rankingMapper.toPriceRankingResponses(results);
+    }
+
+    /** 이번 주 최고가 아이템 TOP N (API 2) */
+    public List<PriceRankingResponse> getWeekHighestPrice(int limit) {
+        List<Object[]> results = rankingRepository.findWeekHighestPrice(limit);
+        return rankingMapper.toPriceRankingResponses(results);
+    }
+
+    /** 오늘의 최대 거래액 TOP N (API 3) */
+    public List<PriceRankingResponse> getTodayLargestVolume(int limit) {
+        List<Object[]> results = rankingRepository.findTodayLargestVolume(limit);
+        return rankingMapper.toPriceRankingResponses(results);
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
@@ -1,0 +1,30 @@
+package until.the.eternity.ranking.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.ranking.domain.mapper.RankingMapper;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+import until.the.eternity.ranking.repository.RankingRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VolumeRankingService {
+
+    private final RankingRepository rankingRepository;
+    private final RankingMapper rankingMapper;
+
+    /** 오늘의 인기 아이템 TOP N (API 4) */
+    public List<VolumeRankingResponse> getTodayPopular(int limit) {
+        List<Object[]> results = rankingRepository.findTodayPopular(limit);
+        return rankingMapper.toVolumeRankingResponses(results);
+    }
+
+    /** 이번 주 인기 아이템 TOP N (API 5) */
+    public List<VolumeRankingResponse> getWeekPopular(int limit) {
+        List<Object[]> results = rankingRepository.findWeekPopular(limit);
+        return rankingMapper.toVolumeRankingResponses(results);
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
+++ b/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
@@ -1,0 +1,190 @@
+package until.the.eternity.ranking.domain.mapper;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.stereotype.Component;
+import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+@Component
+public class RankingMapper {
+
+    /**
+     * Object[] -> PriceRankingResponse 변환 순서: item_name, item_top_category, item_sub_category,
+     * max_price, avg_price, total_volume, total_quantity, date_auction_buy
+     */
+    public List<PriceRankingResponse> toPriceRankingResponses(List<Object[]> results) {
+        return IntStream.range(0, results.size())
+                .mapToObj(
+                        i -> {
+                            Object[] row = results.get(i);
+                            return new PriceRankingResponse(
+                                    i + 1,
+                                    (String) row[0],
+                                    (String) row[1],
+                                    (String) row[2],
+                                    toLong(row[3]),
+                                    toBigDecimal(row[4]),
+                                    toLong(row[5]),
+                                    toLong(row[6]),
+                                    toLocalDate(row[7]));
+                        })
+                .toList();
+    }
+
+    /**
+     * Object[] -> VolumeRankingResponse 변환 순서: item_name, item_top_category, item_sub_category,
+     * total_quantity, total_volume, avg_price, date_auction_buy
+     */
+    public List<VolumeRankingResponse> toVolumeRankingResponses(List<Object[]> results) {
+        return IntStream.range(0, results.size())
+                .mapToObj(
+                        i -> {
+                            Object[] row = results.get(i);
+                            return new VolumeRankingResponse(
+                                    i + 1,
+                                    (String) row[0],
+                                    (String) row[1],
+                                    (String) row[2],
+                                    toLong(row[3]),
+                                    toLong(row[4]),
+                                    toBigDecimal(row[5]),
+                                    toLocalDate(row[6]));
+                        })
+                .toList();
+    }
+
+    /**
+     * Object[] -> PriceChangeRankingResponse 변환 순서: item_name, item_top_category,
+     * item_sub_category, today_avg_price, yesterday_avg_price, change_rate, price_change
+     */
+    public List<PriceChangeRankingResponse> toPriceChangeRankingResponses(List<Object[]> results) {
+        return IntStream.range(0, results.size())
+                .mapToObj(
+                        i -> {
+                            Object[] row = results.get(i);
+                            return new PriceChangeRankingResponse(
+                                    i + 1,
+                                    (String) row[0],
+                                    (String) row[1],
+                                    (String) row[2],
+                                    toBigDecimal(row[3]),
+                                    toBigDecimal(row[4]),
+                                    toBigDecimal(row[5]),
+                                    toLong(row[6]));
+                        })
+                .toList();
+    }
+
+    /**
+     * Object[] -> VolumeChangeRankingResponse 변환 순서: item_name, item_top_category,
+     * item_sub_category, today_quantity, yesterday_quantity, change_rate, quantity_change
+     */
+    public List<VolumeChangeRankingResponse> toVolumeChangeRankingResponses(
+            List<Object[]> results) {
+        return IntStream.range(0, results.size())
+                .mapToObj(
+                        i -> {
+                            Object[] row = results.get(i);
+                            return new VolumeChangeRankingResponse(
+                                    i + 1,
+                                    (String) row[0],
+                                    (String) row[1],
+                                    (String) row[2],
+                                    toLong(row[3]),
+                                    toLong(row[4]),
+                                    toBigDecimal(row[5]),
+                                    toLong(row[6]));
+                        })
+                .toList();
+    }
+
+    /**
+     * Object[] -> AllTimeRankingResponse 변환 순서: item_name, item_display_name, item_top_category,
+     * item_sub_category, auction_price_per_unit, item_count, total_price, date_auction_buy
+     */
+    public List<AllTimeRankingResponse> toAllTimeRankingResponses(List<Object[]> results) {
+        return IntStream.range(0, results.size())
+                .mapToObj(
+                        i -> {
+                            Object[] row = results.get(i);
+                            return new AllTimeRankingResponse(
+                                    i + 1,
+                                    (String) row[0],
+                                    (String) row[1],
+                                    (String) row[2],
+                                    (String) row[3],
+                                    toLong(row[4]),
+                                    toLong(row[5]),
+                                    toLong(row[6]),
+                                    toInstant(row[7]));
+                        })
+                .toList();
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Long) {
+            return (Long) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString());
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDate) {
+            return (LocalDate) value;
+        }
+        if (value instanceof Date) {
+            return ((Date) value).toLocalDate();
+        }
+        if (value instanceof java.util.Date) {
+            return new java.sql.Date(((java.util.Date) value).getTime()).toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    private Instant toInstant(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Instant) {
+            return (Instant) value;
+        }
+        if (value instanceof Timestamp) {
+            return ((Timestamp) value).toInstant();
+        }
+        if (value instanceof java.util.Date) {
+            return ((java.util.Date) value).toInstant();
+        }
+        return Instant.parse(value.toString());
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
@@ -1,0 +1,48 @@
+package until.the.eternity.ranking.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.common.response.ApiResponse;
+import until.the.eternity.ranking.application.service.AllTimeRankingService;
+import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
+import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
+
+@RestController
+@RequestMapping("/rankings/all-time")
+@RequiredArgsConstructor
+@Tag(name = "역대 기록 랭킹 API", description = "역대 최고 기록 랭킹 조회 API")
+public class AllTimeRankingController {
+
+    private final AllTimeRankingService allTimeRankingService;
+
+    @GetMapping("/highest-price")
+    @Operation(
+            summary = "역대 최고가 거래 TOP 100",
+            description = "전체 기간 중 가장 높은 단가로 거래된 아이템 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<AllTimeRankingResponse>>> getAllTimeHighestPrice(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<AllTimeRankingResponse> results =
+                allTimeRankingService.getAllTimeHighestPrice(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/month/largest")
+    @Operation(
+            summary = "이번 달 최대 거래액 TOP 100",
+            description = "이번 달 거래 중 총 거래액(단가 × 수량) 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<AllTimeRankingResponse>>> getMonthLargestVolume(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<AllTimeRankingResponse> results =
+                allTimeRankingService.getMonthLargestVolume(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
@@ -1,0 +1,55 @@
+package until.the.eternity.ranking.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.common.response.ApiResponse;
+import until.the.eternity.ranking.application.service.CategoryRankingService;
+import until.the.eternity.ranking.interfaces.rest.dto.request.CategoryRankingSearchRequest;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+@RestController
+@RequestMapping("/rankings/category")
+@RequiredArgsConstructor
+@Tag(name = "카테고리별 랭킹 API", description = "카테고리별 아이템 랭킹 조회 API")
+public class CategoryRankingController {
+
+    private final CategoryRankingService categoryRankingService;
+
+    @GetMapping("/top-priced")
+    @Operation(
+            summary = "카테고리별 최고가 TOP 100",
+            description = "특정 카테고리 내 오늘 거래된 아이템 중 최고 단가 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceRankingResponse>>> getCategoryTopPriced(
+            @ParameterObject @ModelAttribute @Valid CategoryRankingSearchRequest request) {
+        List<PriceRankingResponse> results =
+                categoryRankingService.getCategoryTopPriced(
+                        request.topCategory(),
+                        request.subCategory(),
+                        request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/popular")
+    @Operation(
+            summary = "카테고리별 인기 아이템 TOP 100",
+            description = "특정 카테고리 내 오늘 거래된 아이템 중 거래 수량 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<VolumeRankingResponse>>> getCategoryPopular(
+            @ParameterObject @ModelAttribute @Valid CategoryRankingSearchRequest request) {
+        List<VolumeRankingResponse> results =
+                categoryRankingService.getCategoryPopular(
+                        request.topCategory(),
+                        request.subCategory(),
+                        request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
@@ -1,0 +1,60 @@
+package until.the.eternity.ranking.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.common.response.ApiResponse;
+import until.the.eternity.ranking.application.service.PriceChangeRankingService;
+import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
+
+@RestController
+@RequestMapping("/rankings/price-change")
+@RequiredArgsConstructor
+@Tag(name = "가격 변동 랭킹 API", description = "어제 대비 가격/거래량 변동 랭킹 조회 API")
+public class PriceChangeRankingController {
+
+    private final PriceChangeRankingService priceChangeRankingService;
+
+    @GetMapping("/surge")
+    @Operation(
+            summary = "가격 급등 TOP 100",
+            description = "어제 대비 오늘 가격이 가장 많이 상승한 아이템 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceChangeRankingResponse>>> getPriceSurge(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<PriceChangeRankingResponse> results =
+                priceChangeRankingService.getPriceSurge(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/drop")
+    @Operation(
+            summary = "가격 급락 TOP 100",
+            description = "어제 대비 오늘 가격이 가장 많이 하락한 아이템 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceChangeRankingResponse>>> getPriceDrop(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<PriceChangeRankingResponse> results =
+                priceChangeRankingService.getPriceDrop(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/volume-surge")
+    @Operation(
+            summary = "거래량 급증 TOP 100",
+            description = "어제 대비 오늘 거래량이 가장 많이 증가한 아이템 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<VolumeChangeRankingResponse>>> getVolumeSurge(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<VolumeChangeRankingResponse> results =
+                priceChangeRankingService.getVolumeSurge(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
@@ -1,0 +1,59 @@
+package until.the.eternity.ranking.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.common.response.ApiResponse;
+import until.the.eternity.ranking.application.service.PriceRankingService;
+import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
+import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+
+@RestController
+@RequestMapping("/rankings/price")
+@RequiredArgsConstructor
+@Tag(name = "가격 랭킹 API", description = "가격 기반 아이템 랭킹 조회 API")
+public class PriceRankingController {
+
+    private final PriceRankingService priceRankingService;
+
+    @GetMapping("/today/highest")
+    @Operation(
+            summary = "오늘의 최고가 거래 TOP 100",
+            description = "오늘 거래된 아이템 중 최고 단가 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceRankingResponse>>> getTodayHighestPrice(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<PriceRankingResponse> results =
+                priceRankingService.getTodayHighestPrice(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/week/highest")
+    @Operation(
+            summary = "이번 주 최고가 아이템 TOP 100",
+            description = "이번 주 거래된 아이템 중 최고 단가 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceRankingResponse>>> getWeekHighestPrice(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<PriceRankingResponse> results =
+                priceRankingService.getWeekHighestPrice(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/today/largest")
+    @Operation(
+            summary = "오늘의 최대 거래액 TOP 100",
+            description = "오늘 거래된 아이템 중 총 거래액(거래량 × 단가) 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PriceRankingResponse>>> getTodayLargestVolume(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<PriceRankingResponse> results =
+                priceRankingService.getTodayLargestVolume(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
@@ -1,0 +1,48 @@
+package until.the.eternity.ranking.interfaces.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.common.response.ApiResponse;
+import until.the.eternity.ranking.application.service.VolumeRankingService;
+import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
+import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+@RestController
+@RequestMapping("/rankings/volume")
+@RequiredArgsConstructor
+@Tag(name = "거래량 랭킹 API", description = "거래량 기반 인기 아이템 랭킹 조회 API")
+public class VolumeRankingController {
+
+    private final VolumeRankingService volumeRankingService;
+
+    @GetMapping("/today/popular")
+    @Operation(
+            summary = "오늘의 인기 아이템 TOP 100",
+            description = "오늘 거래된 아이템 중 거래 수량 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<VolumeRankingResponse>>> getTodayPopular(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<VolumeRankingResponse> results =
+                volumeRankingService.getTodayPopular(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+
+    @GetMapping("/week/popular")
+    @Operation(
+            summary = "이번 주 인기 아이템 TOP 100",
+            description = "이번 주 거래된 아이템 중 거래 수량 기준 TOP 100을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<VolumeRankingResponse>>> getWeekPopular(
+            @ParameterObject @ModelAttribute @Valid RankingSearchRequest request) {
+        List<VolumeRankingResponse> results =
+                volumeRankingService.getWeekPopular(request.getLimitWithDefault());
+        return ResponseEntity.ok(ApiResponse.success(results));
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/request/CategoryRankingSearchRequest.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/request/CategoryRankingSearchRequest.java
@@ -1,0 +1,23 @@
+package until.the.eternity.ranking.interfaces.rest.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import until.the.eternity.ranking.util.RankingConstants;
+
+@Schema(description = "카테고리별 랭킹 검색 요청")
+public record CategoryRankingSearchRequest(
+        @NotBlank(message = "탑 카테고리는 필수입니다")
+                @Schema(description = "아이템 탑 카테고리", example = "무기", required = true)
+                String topCategory,
+        @Schema(description = "아이템 서브 카테고리 (선택)", example = "한손검") String subCategory,
+        @Schema(description = "조회할 랭킹 개수 (기본값: 100, 최대: 100)", example = "100")
+                @Min(value = 1, message = "limit은 최소 1 이상이어야 합니다")
+                @Max(value = 100, message = "limit은 최대 100까지 가능합니다")
+                Integer limit) {
+
+    public int getLimitWithDefault() {
+        return limit != null ? limit : RankingConstants.DEFAULT_LIMIT;
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/request/RankingSearchRequest.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/request/RankingSearchRequest.java
@@ -1,0 +1,18 @@
+package until.the.eternity.ranking.interfaces.rest.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import until.the.eternity.ranking.util.RankingConstants;
+
+@Schema(description = "랭킹 검색 요청")
+public record RankingSearchRequest(
+        @Schema(description = "조회할 랭킹 개수 (기본값: 100, 최대: 100)", example = "100")
+                @Min(value = 1, message = "limit은 최소 1 이상이어야 합니다")
+                @Max(value = 100, message = "limit은 최대 100까지 가능합니다")
+                Integer limit) {
+
+    public int getLimitWithDefault() {
+        return limit != null ? limit : RankingConstants.DEFAULT_LIMIT;
+    }
+}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
@@ -1,0 +1,19 @@
+package until.the.eternity.ranking.interfaces.rest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+@Schema(description = "역대 기록 랭킹 응답")
+public record AllTimeRankingResponse(
+        @Schema(description = "순위", example = "1") Integer rank,
+        @Schema(description = "아이템 이름", example = "켈틱 로열 나이트 소드") String itemName,
+        @Schema(description = "아이템 표시 이름", example = "켈틱 로열 나이트 소드 (인챈트)") String itemDisplayName,
+        @Schema(description = "아이템 탑 카테고리", example = "무기") String itemTopCategory,
+        @Schema(description = "아이템 서브 카테고리", example = "한손검") String itemSubCategory,
+        @Schema(description = "단가 (개당 가격)", example = "999999999") Long auctionPricePerUnit,
+        @Schema(description = "거래 수량", example = "1") Long itemCount,
+        @Schema(description = "총 거래 금액", example = "999999999") Long totalPrice,
+        @Schema(description = "거래 일시", example = "2025-07-01T14:35:00Z")
+                @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+                Instant dateAuctionBuy) {}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
@@ -1,0 +1,15 @@
+package until.the.eternity.ranking.interfaces.rest.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+@Schema(description = "가격 변동 랭킹 응답")
+public record PriceChangeRankingResponse(
+        @Schema(description = "순위", example = "1") Integer rank,
+        @Schema(description = "아이템 이름", example = "켈틱 로열 나이트 소드") String itemName,
+        @Schema(description = "아이템 탑 카테고리", example = "무기") String itemTopCategory,
+        @Schema(description = "아이템 서브 카테고리", example = "한손검") String itemSubCategory,
+        @Schema(description = "오늘 평균 단가", example = "150000000.00") BigDecimal todayAvgPrice,
+        @Schema(description = "어제 평균 단가", example = "100000000.00") BigDecimal yesterdayAvgPrice,
+        @Schema(description = "변동률 (%)", example = "50.00") BigDecimal changeRate,
+        @Schema(description = "변동액", example = "50000000") Long priceChange) {}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
@@ -1,0 +1,19 @@
+package until.the.eternity.ranking.interfaces.rest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "가격 랭킹 응답")
+public record PriceRankingResponse(
+        @Schema(description = "순위", example = "1") Integer rank,
+        @Schema(description = "아이템 이름", example = "켈틱 로열 나이트 소드") String itemName,
+        @Schema(description = "아이템 탑 카테고리", example = "무기") String itemTopCategory,
+        @Schema(description = "아이템 서브 카테고리", example = "한손검") String itemSubCategory,
+        @Schema(description = "최고 단가", example = "150000000") Long maxPrice,
+        @Schema(description = "평균 단가", example = "135000000.50") BigDecimal avgPrice,
+        @Schema(description = "거래 총량 (총 거래 금액)", example = "5000000000") Long totalVolume,
+        @Schema(description = "거래 수량", example = "150") Long totalQuantity,
+        @Schema(description = "거래 일자", example = "2025-07-01") @JsonFormat(pattern = "yyyy-MM-dd")
+                LocalDate dateAuctionBuy) {}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
@@ -1,0 +1,15 @@
+package until.the.eternity.ranking.interfaces.rest.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+@Schema(description = "거래량 변동 랭킹 응답")
+public record VolumeChangeRankingResponse(
+        @Schema(description = "순위", example = "1") Integer rank,
+        @Schema(description = "아이템 이름", example = "축복의 포션") String itemName,
+        @Schema(description = "아이템 탑 카테고리", example = "소모품") String itemTopCategory,
+        @Schema(description = "아이템 서브 카테고리", example = "포션") String itemSubCategory,
+        @Schema(description = "오늘 거래 수량", example = "15000") Long todayQuantity,
+        @Schema(description = "어제 거래 수량", example = "5000") Long yesterdayQuantity,
+        @Schema(description = "변동률 (%)", example = "200.00") BigDecimal changeRate,
+        @Schema(description = "변동량", example = "10000") Long quantityChange) {}

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
@@ -1,0 +1,18 @@
+package until.the.eternity.ranking.interfaces.rest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "거래량 랭킹 응답")
+public record VolumeRankingResponse(
+        @Schema(description = "순위", example = "1") Integer rank,
+        @Schema(description = "아이템 이름", example = "축복의 포션") String itemName,
+        @Schema(description = "아이템 탑 카테고리", example = "소모품") String itemTopCategory,
+        @Schema(description = "아이템 서브 카테고리", example = "포션") String itemSubCategory,
+        @Schema(description = "거래 수량", example = "15000") Long totalQuantity,
+        @Schema(description = "거래 총량 (총 거래 금액)", example = "500000000") Long totalVolume,
+        @Schema(description = "평균 단가", example = "33333.33") BigDecimal avgPrice,
+        @Schema(description = "거래 일자", example = "2025-07-01") @JsonFormat(pattern = "yyyy-MM-dd")
+                LocalDate dateAuctionBuy) {}

--- a/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
+++ b/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
@@ -1,0 +1,296 @@
+package until.the.eternity.ranking.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
+
+public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Long> {
+
+    // ===== 가격 랭킹 (Price Ranking) =====
+
+    /** 오늘의 최고가 거래 TOP N (API 1) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.max_price,
+                        i.avg_price,
+                        i.total_volume,
+                        i.total_quantity,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                    ORDER BY i.max_price DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findTodayHighestPrice(@Param("limit") int limit);
+
+    /** 이번 주 최고가 아이템 TOP N (API 2) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.max_price,
+                        i.avg_price,
+                        i.total_volume,
+                        i.total_quantity,
+                        i.week_start_date AS date_auction_buy
+                    FROM item_weekly_statistics i
+                    WHERE i.year = YEAR(CURDATE())
+                      AND i.week_number = WEEK(CURDATE(), 1)
+                    ORDER BY i.max_price DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findWeekHighestPrice(@Param("limit") int limit);
+
+    /** 오늘의 최대 거래액 TOP N (API 3) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.max_price,
+                        i.avg_price,
+                        i.total_volume,
+                        i.total_quantity,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                    ORDER BY i.total_volume DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findTodayLargestVolume(@Param("limit") int limit);
+
+    // ===== 거래량 랭킹 (Volume Ranking) =====
+
+    /** 오늘의 인기 아이템 TOP N (API 4) - 거래 수량 기준 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.total_quantity,
+                        i.total_volume,
+                        i.avg_price,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                    ORDER BY i.total_quantity DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findTodayPopular(@Param("limit") int limit);
+
+    /** 이번 주 인기 아이템 TOP N (API 5) - 거래 수량 기준 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.total_quantity,
+                        i.total_volume,
+                        i.avg_price,
+                        i.week_start_date AS date_auction_buy
+                    FROM item_weekly_statistics i
+                    WHERE i.year = YEAR(CURDATE())
+                      AND i.week_number = WEEK(CURDATE(), 1)
+                    ORDER BY i.total_quantity DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findWeekPopular(@Param("limit") int limit);
+
+    // ===== 가격 변동 랭킹 (Price Change Ranking) =====
+
+    /** 가격 급등 TOP N (API 6) - 어제 대비 오늘 가격 상승률 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        t.item_name,
+                        t.item_top_category,
+                        t.item_sub_category,
+                        t.avg_price AS today_avg_price,
+                        y.avg_price AS yesterday_avg_price,
+                        ROUND(((t.avg_price - y.avg_price) / y.avg_price) * 100, 2) AS change_rate,
+                        (t.avg_price - y.avg_price) AS price_change
+                    FROM item_daily_statistics t
+                    INNER JOIN item_daily_statistics y
+                        ON t.item_name = y.item_name
+                        AND t.item_top_category = y.item_top_category
+                        AND t.item_sub_category = y.item_sub_category
+                    WHERE t.date_auction_buy = CURDATE()
+                      AND y.date_auction_buy = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+                      AND y.avg_price > 0
+                    ORDER BY change_rate DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findPriceSurge(@Param("limit") int limit);
+
+    /** 가격 급락 TOP N (API 7) - 어제 대비 오늘 가격 하락률 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        t.item_name,
+                        t.item_top_category,
+                        t.item_sub_category,
+                        t.avg_price AS today_avg_price,
+                        y.avg_price AS yesterday_avg_price,
+                        ROUND(((t.avg_price - y.avg_price) / y.avg_price) * 100, 2) AS change_rate,
+                        (t.avg_price - y.avg_price) AS price_change
+                    FROM item_daily_statistics t
+                    INNER JOIN item_daily_statistics y
+                        ON t.item_name = y.item_name
+                        AND t.item_top_category = y.item_top_category
+                        AND t.item_sub_category = y.item_sub_category
+                    WHERE t.date_auction_buy = CURDATE()
+                      AND y.date_auction_buy = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+                      AND y.avg_price > 0
+                    ORDER BY change_rate ASC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findPriceDrop(@Param("limit") int limit);
+
+    /** 거래량 급증 TOP N (API 8) - 어제 대비 오늘 거래량 증가율 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        t.item_name,
+                        t.item_top_category,
+                        t.item_sub_category,
+                        t.total_quantity AS today_quantity,
+                        y.total_quantity AS yesterday_quantity,
+                        ROUND(((t.total_quantity - y.total_quantity) / y.total_quantity) * 100, 2) AS change_rate,
+                        (t.total_quantity - y.total_quantity) AS quantity_change
+                    FROM item_daily_statistics t
+                    INNER JOIN item_daily_statistics y
+                        ON t.item_name = y.item_name
+                        AND t.item_top_category = y.item_top_category
+                        AND t.item_sub_category = y.item_sub_category
+                    WHERE t.date_auction_buy = CURDATE()
+                      AND y.date_auction_buy = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+                      AND y.total_quantity > 0
+                    ORDER BY change_rate DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findVolumeSurge(@Param("limit") int limit);
+
+    // ===== 카테고리별 랭킹 (Category Ranking) =====
+
+    /** 카테고리별 최고가 TOP N (API 9) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.max_price,
+                        i.avg_price,
+                        i.total_volume,
+                        i.total_quantity,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                      AND i.item_top_category = :topCategory
+                      AND (:subCategory IS NULL OR i.item_sub_category = :subCategory)
+                    ORDER BY i.max_price DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findCategoryTopPriced(
+            @Param("topCategory") String topCategory,
+            @Param("subCategory") String subCategory,
+            @Param("limit") int limit);
+
+    /** 카테고리별 인기 아이템 TOP N (API 10) - 거래 수량 기준 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.total_quantity,
+                        i.total_volume,
+                        i.avg_price,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                      AND i.item_top_category = :topCategory
+                      AND (:subCategory IS NULL OR i.item_sub_category = :subCategory)
+                    ORDER BY i.total_quantity DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findCategoryPopular(
+            @Param("topCategory") String topCategory,
+            @Param("subCategory") String subCategory,
+            @Param("limit") int limit);
+
+    // ===== 역대 기록 랭킹 (All-Time Ranking) =====
+
+    /** 역대 최고가 거래 TOP N (API 11) - 원본 거래 내역 기반 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        ah.item_name,
+                        ah.item_display_name,
+                        ah.item_top_category,
+                        ah.item_sub_category,
+                        ah.auction_price_per_unit,
+                        ah.item_count,
+                        (ah.auction_price_per_unit * ah.item_count) AS total_price,
+                        ah.date_auction_buy
+                    FROM auction_history ah
+                    ORDER BY ah.auction_price_per_unit DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findAllTimeHighestPrice(@Param("limit") int limit);
+
+    /** 이번 달 최대 거래액 TOP N (API 12) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        ah.item_name,
+                        ah.item_display_name,
+                        ah.item_top_category,
+                        ah.item_sub_category,
+                        ah.auction_price_per_unit,
+                        ah.item_count,
+                        (ah.auction_price_per_unit * ah.item_count) AS total_price,
+                        ah.date_auction_buy
+                    FROM auction_history ah
+                    WHERE YEAR(ah.date_auction_buy) = YEAR(CURDATE())
+                      AND MONTH(ah.date_auction_buy) = MONTH(CURDATE())
+                    ORDER BY (ah.auction_price_per_unit * ah.item_count) DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findMonthLargestVolume(@Param("limit") int limit);
+}

--- a/src/main/java/until/the/eternity/ranking/util/RankingConstants.java
+++ b/src/main/java/until/the/eternity/ranking/util/RankingConstants.java
@@ -1,0 +1,10 @@
+package until.the.eternity.ranking.util;
+
+public final class RankingConstants {
+
+    private RankingConstants() {}
+
+    public static final int DEFAULT_LIMIT = 100;
+    public static final int MIN_LIMIT = 1;
+    public static final int MAX_LIMIT = 100;
+}

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
@@ -2,11 +2,10 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
@@ -1,9 +1,8 @@
 package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "일간 통계 검색 요청")
 public record DailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "아이템별 일간 통계 검색 요청")
 public record ItemDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "아이템별 주간 통계 검색 요청")
 public record ItemWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "서브카테고리별 일간 통계 검색 요청")
 public record SubcategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "서브카테고리별 주간 통계 검색 요청")
 public record SubcategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "탑카테고리별 일간 통계 검색 요청")
 public record TopCategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
@@ -2,9 +2,8 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "탑카테고리별 주간 통계 검색 요청")
 public record TopCategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
@@ -1,14 +1,13 @@
 package until.the.eternity.statistics.repository.daily;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public interface ItemDailyStatisticsRepository extends JpaRepository<ItemDailyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
@@ -1,14 +1,13 @@
 package until.the.eternity.statistics.repository.daily;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.SubcategoryDailyStatistics;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public interface SubcategoryDailyStatisticsRepository
         extends JpaRepository<SubcategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
@@ -1,14 +1,13 @@
 package until.the.eternity.statistics.repository.daily;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.TopCategoryDailyStatistics;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public interface TopCategoryDailyStatisticsRepository
         extends JpaRepository<TopCategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
@@ -1,13 +1,12 @@
 package until.the.eternity.statistics.repository.weekly;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.ItemWeeklyStatistics;
-
-import java.util.List;
 
 public interface ItemWeeklyStatisticsRepository extends JpaRepository<ItemWeeklyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
@@ -1,13 +1,12 @@
 package until.the.eternity.statistics.repository.weekly;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.SubcategoryWeeklyStatistics;
-
-import java.util.List;
 
 public interface SubcategoryWeeklyStatisticsRepository
         extends JpaRepository<SubcategoryWeeklyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
@@ -1,13 +1,12 @@
 package until.the.eternity.statistics.repository.weekly;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.TopCategoryWeeklyStatistics;
-
-import java.util.List;
 
 public interface TopCategoryWeeklyStatisticsRepository
         extends JpaRepository<TopCategoryWeeklyStatistics, Long> {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.auctionhistory.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,13 +26,6 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryServiceTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
@@ -1,5 +1,13 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,15 +21,6 @@ import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryCli
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryListResponse;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalInt;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryFetcherTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,13 +18,6 @@ import until.the.eternity.auctionhistory.domain.mapper.OpenApiAuctionHistoryMapp
 import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateChecker;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryPersisterTest {

--- a/src/test/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateCheckerTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateCheckerTest.java
@@ -1,5 +1,13 @@
 package until.the.eternity.auctionhistory.domain.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,15 +19,6 @@ import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryReposit
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort.LatestDateWithIds;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryDuplicateCheckerTest {

--- a/src/test/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcherTest.java
@@ -1,5 +1,12 @@
 package until.the.eternity.auctionrealtime.application.service.fetcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,14 +22,6 @@ import until.the.eternity.auctionrealtime.infrastructure.client.AuctionRealtimeC
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeListResponse;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionRealtimeFetcherTest {

--- a/src/test/java/until/the/eternity/auctionrealtime/domain/service/AuctionRealtimeDuplicateCheckerTest.java
+++ b/src/test/java/until/the/eternity/auctionrealtime/domain/service/AuctionRealtimeDuplicateCheckerTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.auctionrealtime.domain.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,13 +17,6 @@ import until.the.eternity.auctionrealtime.domain.repository.AuctionRealtimeItemR
 import until.the.eternity.auctionrealtime.domain.service.AuctionRealtimeDuplicateChecker.DuplicateCheckResult;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionRealtimeDuplicateCheckerTest {

--- a/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
@@ -1,6 +1,11 @@
 package until.the.eternity.auctionsearchoption.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,12 +16,6 @@ import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionM
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionSearchOptionServiceTest {

--- a/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
+++ b/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
@@ -1,5 +1,11 @@
 package until.the.eternity.iteminfo.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,13 +24,6 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ItemInfoServiceTest {

--- a/src/test/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoServiceTest.java
+++ b/src/test/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoServiceTest.java
@@ -1,5 +1,10 @@
 package until.the.eternity.metalwareinfo.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,12 +13,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MetalwareInfoServiceTest {


### PR DESCRIPTION
## 📋 상세 설명

- 경매 아이템에 대해 가격·거래량·변동률·카테고리·역대 기록을 포함한 12종 랭킹 API 구현
- ItemOptionInfo 엔티티의 CRUD 기능(생성·수정·삭제) 추가

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [ ] 문서는 업데이트 되었나요 `추후에 업데이트`
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `라벨만 등록`
