### PR TITLE
feat: 요청 파라미터에 기본 정렬 조건 설정 및 페이지네이션 요청 값 검증

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -46,6 +46,11 @@ services:
       AUCTION_HISTORY_CRON: "${AUCTION_HISTORY_CRON}"
       STATISTICS_PREVIOUS_DAY_CRON: "${STATISTICS_PREVIOUS_DAY_CRON:-0 0 * * * *}"
 
+      # === Elasticsearch Configuration (Dev 기본 비활성화) ===
+      ELASTICSEARCH_ENABLED: "false"
+      ELASTICSEARCH_INDEX_ENABLED: "false"
+      MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED: "false"
+
       # === Docker Configuration ===
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_REPO: ${DOCKER_REPO}

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -51,6 +51,7 @@ services:
       ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-true}
       ELASTICSEARCH_INDEX_ENABLED: ${ELASTICSEARCH_INDEX_ENABLED:-true}
       SPRING_ELASTICSEARCH_URIS: http://elasticsearch:9200
+      MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED: "false"
 
       # === JVM Configuration (Local - 경량 개발용) ===
       # Heap: 256m~512m, Non-Heap: 256m, Total: ~768m
@@ -90,11 +91,9 @@ services:
       - app-network
       - my-network  # MySQL 컨테이너와 통신을 위해 추가
 
-    # MySQL, Elasticsearch가 준비될 때까지 대기
+    # MySQL 준비될 때까지 대기 (Elasticsearch는 선택 의존성)
     depends_on:
       mysql:
-        condition: service_healthy
-      elasticsearch:
         condition: service_healthy
 
     # === Health Check (Local - 표준) ===

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -18,10 +18,6 @@ services:
     labels:
       autoheal: "true"
 
-    depends_on:
-      devnogi-elastic-search:
-        condition: service_healthy
-
     environment:
       # === Application Configuration ===
       SPRING_PROFILES_ACTIVE: prod
@@ -51,6 +47,7 @@ services:
       ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-true}
       ELASTICSEARCH_INDEX_ENABLED: ${ELASTICSEARCH_INDEX_ENABLED:-true}
       SPRING_ELASTICSEARCH_URIS: http://devnogi-elastic-search:9200
+      MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED: "false"
 
       # === Docker Configuration ===
       DOCKER_USERNAME: ${DOCKER_USERNAME}

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -409,13 +409,13 @@ class AuctionRealtimeQueryDslRepository {
                             case "auctionPricePerUnit" ->
                                     new OrderSpecifier<>(direction, ar.auctionPricePerUnit);
                             case "itemName" -> new OrderSpecifier<>(direction, ar.itemName);
-                            default -> new OrderSpecifier<>(Order.ASC, ar.dateAuctionExpire);
+                            default -> new OrderSpecifier<>(Order.DESC, ar.dateAuctionExpire);
                         };
 
                 orders.add(orderSpecifier);
             }
         } else {
-            orders.add(new OrderSpecifier<>(Order.ASC, ar.dateAuctionExpire));
+            orders.add(new OrderSpecifier<>(Order.DESC, ar.dateAuctionExpire));
         }
 
         return orders;

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimePageRequestDto.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimePageRequestDto.java
@@ -11,22 +11,25 @@ import until.the.eternity.common.enums.SortDirection;
 @Schema(description = "실시간 경매장 페이지 요청 파라미터")
 public record RealtimePageRequestDto(
         @Schema(description = "요청할 페이지 번호 (1부터 시작)", example = "1") @Min(1) Integer page,
-        @Schema(description = "페이지당 항목 수", example = "20") @Min(1) @Max(100) Integer size,
+        @Schema(description = "페이지당 항목 수 (10~50)", example = "20") @Min(10) @Max(50) Integer size,
         @Schema(
                         description =
-                                "정렬 필드 (dateAuctionExpire, dateRegister, auctionPricePerUnit, itemName)",
+                                "정렬 필드 (dateAuctionExpire, dateAuctionRegister, auctionPricePerUnit, itemName)",
                         example = "dateAuctionExpire")
                 RealtimeSortField sortBy,
-        @Schema(description = "정렬 방향 (ASC, DESC)", example = "ASC") SortDirection direction) {
+        @Schema(description = "정렬 방향 (ASC, DESC)", example = "DESC") SortDirection direction) {
 
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 20;
+    private static final int MIN_SIZE = 10;
+    private static final int MAX_SIZE = 50;
     private static final RealtimeSortField DEFAULT_SORT_BY = RealtimeSortField.DATE_AUCTION_EXPIRE;
-    private static final SortDirection DEFAULT_DIRECTION = SortDirection.ASC;
+    private static final SortDirection DEFAULT_DIRECTION = SortDirection.DESC;
 
     public Pageable toPageable() {
         int resolvedPage = this.page != null ? this.page - 1 : DEFAULT_PAGE - 1;
         int resolvedSize = this.size != null ? this.size : DEFAULT_SIZE;
+        resolvedSize = Math.max(MIN_SIZE, Math.min(MAX_SIZE, resolvedSize));
         RealtimeSortField resolvedSortBy = this.sortBy != null ? this.sortBy : DEFAULT_SORT_BY;
         SortDirection resolvedDirection =
                 this.direction != null ? this.direction : DEFAULT_DIRECTION;

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 @Schema(description = "실시간 경매장 정렬 필드", enumAsRef = true)
 public enum RealtimeSortField {
     DATE_AUCTION_EXPIRE("dateAuctionExpire", "경매 만료 일시"),
-    DATE_REGISTER("dateRegister", "등록 일시"),
+    DATE_AUCTION_REGISTER("dateRegister", "등록 일시"),
     AUCTION_PRICE_PER_UNIT("auctionPricePerUnit", "개당 가격"),
     ITEM_NAME("itemName", "아이템 이름");
 

--- a/src/main/java/until/the/eternity/common/request/PageRequestDto.java
+++ b/src/main/java/until/the/eternity/common/request/PageRequestDto.java
@@ -12,7 +12,7 @@ import until.the.eternity.common.enums.SortField;
 @Schema(description = "페이지 요청 파라미터")
 public record PageRequestDto(
         @Schema(description = "요청할 페이지 번호 (1부터 시작)", example = "1") @Min(1) Integer page,
-        @Schema(description = "페이지당 항목 수", example = "20") @Min(1) @Max(100) Integer size,
+        @Schema(description = "페이지당 항목 수 (10~50)", example = "20") @Min(10) @Max(50) Integer size,
         @Schema(
                         description = "정렬 필드 (dateAuctionBuy, auctionPricePerUnit, itemName)",
                         example = "dateAuctionBuy")
@@ -20,12 +20,15 @@ public record PageRequestDto(
         @Schema(description = "정렬 방향 (ASC, DESC)", example = "DESC") SortDirection direction) {
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 20;
+    private static final int MIN_SIZE = 10;
+    private static final int MAX_SIZE = 50;
     private static final SortField DEFAULT_SORT_BY = SortField.DATE_AUCTION_BUY;
     private static final SortDirection DEFAULT_DIRECTION = SortDirection.DESC;
 
     public Pageable toPageable() {
         int resolvedPage = this.page != null ? this.page - 1 : DEFAULT_PAGE - 1;
         int resolvedSize = this.size != null ? this.size : DEFAULT_SIZE;
+        resolvedSize = Math.max(MIN_SIZE, Math.min(MAX_SIZE, resolvedSize));
         SortField resolvedSortBy = this.sortBy != null ? this.sortBy : DEFAULT_SORT_BY;
         SortDirection resolvedDirection =
                 this.direction != null ? this.direction : DEFAULT_DIRECTION;

--- a/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
+++ b/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
@@ -7,10 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
-import until.the.eternity.common.exception.CustomException;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
-import until.the.eternity.iteminfo.domain.exception.ItemInfoExceptionCode;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResponse;
@@ -53,7 +51,6 @@ public class ItemInfoService {
 
     public Page<ItemInfoResponse> findAllDetail(
             ItemInfoSearchRequest searchRequest, Pageable pageable) {
-        validateTopCategory(searchRequest);
         Page<ItemInfo> itemInfoPage =
                 itemInfoRepository.searchWithPagination(searchRequest, pageable);
         return itemInfoPage.map(ItemInfoResponse::from);
@@ -62,7 +59,6 @@ public class ItemInfoService {
     public List<ItemInfoSummaryResponse> findAllSummary(
             ItemInfoSearchRequest searchRequest,
             org.springframework.data.domain.Sort.Direction direction) {
-        validateTopCategory(searchRequest);
         // direction을 Pageable로 변환
         Pageable pageable =
                 org.springframework.data.domain.PageRequest.of(
@@ -71,12 +67,6 @@ public class ItemInfoService {
                         org.springframework.data.domain.Sort.by(direction, "id.name"));
         List<ItemInfo> itemInfos = itemInfoRepository.search(searchRequest, pageable);
         return ItemInfoSummaryResponse.from(itemInfos);
-    }
-
-    private void validateTopCategory(ItemInfoSearchRequest searchRequest) {
-        if (searchRequest.topCategory() == null || searchRequest.topCategory().isBlank()) {
-            throw new CustomException(ItemInfoExceptionCode.TOP_CATEGORY_REQUIRED);
-        }
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -45,8 +45,9 @@ public class ItemInfoController {
             summary = "아이템 상세 정보 페이지네이션 조회",
             description =
                     "아이템 정보를 페이지네이션과 함께 조회합니다. "
-                            + "topCategory는 필수 파라미터이며, name, subCategory로 추가 필터링 가능합니다. "
-                            + "name 컬럼 기준으로 정렬됩니다.")
+                            + "topCategory는 선택 파라미터이며, name, subCategory로 추가 필터링 가능합니다. "
+                            + "정렬 기준은 item_name(ASC/DESC)이고 기본값은 ASC입니다. "
+                            + "page는 1 이상, size는 10~50 사이 값만 허용됩니다.")
     @GetMapping("/detail")
     public ResponseEntity<ApiResponse<Page<ItemInfoResponse>>> getItemInfosDetail(
             @Valid @ModelAttribute ItemInfoPageRequestDto pageRequest,
@@ -60,8 +61,8 @@ public class ItemInfoController {
             summary = "아이템 요약 정보 조회",
             description =
                     "아이템의 이름, 상위 카테고리, 하위 카테고리만 조회합니다. "
-                            + "topCategory는 필수 파라미터이며, name, subCategory로 추가 필터링 가능합니다. "
-                            + "name 컬럼 기준으로 정렬됩니다.")
+                            + "topCategory는 선택 파라미터이며, name, subCategory로 추가 필터링 가능합니다. "
+                            + "정렬 기준은 item_name이며 direction 파라미터로 ASC/DESC를 지정합니다.")
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<List<ItemInfoSummaryResponse>>> getItemInfosSummary(
             @Parameter(description = "정렬 방향 (ASC, DESC)", example = "ASC")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/request/ItemInfoPageRequestDto.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/request/ItemInfoPageRequestDto.java
@@ -11,16 +11,20 @@ import until.the.eternity.common.enums.SortDirection;
 @Schema(description = "아이템 정보 페이지 요청 파라미터")
 public record ItemInfoPageRequestDto(
         @Schema(description = "요청할 페이지 번호 (1부터 시작)", example = "1") @Min(1) Integer page,
-        @Schema(description = "페이지당 항목 수", example = "20") @Min(1) @Max(50) Integer size,
-        @Schema(description = "정렬 방향 (ASC, DESC)", example = "ASC") SortDirection direction) {
+        @Schema(description = "페이지당 항목 수 (10~50)", example = "20") @Min(10) @Max(50) Integer size,
+        @Schema(description = "정렬 방향 (item_name 기준 ASC, DESC)", example = "ASC")
+                SortDirection direction) {
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 20;
+    private static final int MIN_SIZE = 10;
+    private static final int MAX_SIZE = 50;
     private static final SortDirection DEFAULT_DIRECTION = SortDirection.ASC;
     private static final String SORT_FIELD = "id.name";
 
     public Pageable toPageable() {
         int resolvedPage = this.page != null ? this.page - 1 : DEFAULT_PAGE - 1;
         int resolvedSize = this.size != null ? this.size : DEFAULT_SIZE;
+        resolvedSize = Math.max(MIN_SIZE, Math.min(MAX_SIZE, resolvedSize));
         SortDirection resolvedDirection =
                 this.direction != null ? this.direction : DEFAULT_DIRECTION;
 

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/request/ItemInfoSearchRequest.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/request/ItemInfoSearchRequest.java
@@ -1,12 +1,9 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "아이템 정보 검색 요청 파라미터")
 public record ItemInfoSearchRequest(
         @Schema(description = "아이템 이름", example = "나뭇가지") String name,
         @Schema(description = "하위 카테고리", example = "한손검") String subCategory,
-        @Schema(description = "상위 카테고리 (필수)", example = "무기", required = true)
-                @NotBlank(message = "상위 카테고리(topCategory)는 필수 파라미터입니다.")
-                String topCategory) {}
+        @Schema(description = "상위 카테고리 (선택)", example = "무기") String topCategory) {}

--- a/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
+++ b/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
@@ -8,10 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
-import until.the.eternity.common.exception.CustomException;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
-import until.the.eternity.iteminfo.domain.exception.ItemInfoExceptionCode;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResponse;
@@ -23,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -118,29 +115,37 @@ class ItemInfoServiceTest {
     }
 
     @Test
-    @DisplayName("상세 정보 조회 시 topCategory가 없으면 예외가 발생한다")
-    void findAllDetail_should_throw_exception_when_topCategory_is_null() {
+    @DisplayName("상세 정보 조회 시 topCategory가 없어도 조회된다")
+    void findAllDetail_should_allow_null_topCategory() {
         // given
         ItemInfoSearchRequest searchRequest = new ItemInfoSearchRequest(null, null, null);
         Pageable pageable = PageRequest.of(0, 20);
+        Page<ItemInfo> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        when(itemInfoRepository.searchWithPagination(searchRequest, pageable)).thenReturn(emptyPage);
 
-        // when & then
-        assertThatThrownBy(() -> itemInfoService.findAllDetail(searchRequest, pageable))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ItemInfoExceptionCode.TOP_CATEGORY_REQUIRED.getMessage());
+        // when
+        Page<ItemInfoResponse> result = itemInfoService.findAllDetail(searchRequest, pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        verify(itemInfoRepository).searchWithPagination(searchRequest, pageable);
     }
 
     @Test
-    @DisplayName("상세 정보 조회 시 topCategory가 빈 문자열이면 예외가 발생한다")
-    void findAllDetail_should_throw_exception_when_topCategory_is_blank() {
+    @DisplayName("상세 정보 조회 시 topCategory가 공백이어도 조회된다")
+    void findAllDetail_should_allow_blank_topCategory() {
         // given
         ItemInfoSearchRequest searchRequest = new ItemInfoSearchRequest(null, null, "");
         Pageable pageable = PageRequest.of(0, 20);
+        Page<ItemInfo> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        when(itemInfoRepository.searchWithPagination(searchRequest, pageable)).thenReturn(emptyPage);
 
-        // when & then
-        assertThatThrownBy(() -> itemInfoService.findAllDetail(searchRequest, pageable))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ItemInfoExceptionCode.TOP_CATEGORY_REQUIRED.getMessage());
+        // when
+        Page<ItemInfoResponse> result = itemInfoService.findAllDetail(searchRequest, pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        verify(itemInfoRepository).searchWithPagination(searchRequest, pageable);
     }
 
     @Test
@@ -191,15 +196,19 @@ class ItemInfoServiceTest {
     }
 
     @Test
-    @DisplayName("요약 정보 조회 시 topCategory가 없으면 예외가 발생한다")
-    void findAllSummary_should_throw_exception_when_topCategory_is_null() {
+    @DisplayName("요약 정보 조회 시 topCategory 없이도 조회된다")
+    void findAllSummary_should_allow_null_topCategory() {
         // given
         ItemInfoSearchRequest searchRequest = new ItemInfoSearchRequest(null, null, null);
+        when(itemInfoRepository.search(eq(searchRequest), any(Pageable.class))).thenReturn(List.of());
 
-        // when & then
-        assertThatThrownBy(() -> itemInfoService.findAllSummary(searchRequest, Sort.Direction.ASC))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ItemInfoExceptionCode.TOP_CATEGORY_REQUIRED.getMessage());
+        // when
+        List<ItemInfoSummaryResponse> result =
+                itemInfoService.findAllSummary(searchRequest, Sort.Direction.ASC);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(itemInfoRepository).search(eq(searchRequest), any(Pageable.class));
     }
 
     @Test
@@ -319,15 +328,19 @@ class ItemInfoServiceTest {
     }
 
     @Test
-    @DisplayName("요약 정보 조회 시 topCategory가 빈 문자열이면 예외가 발생한다")
-    void findAllSummary_should_throw_exception_when_topCategory_is_blank() {
+    @DisplayName("요약 정보 조회 시 topCategory가 공백이어도 조회된다")
+    void findAllSummary_should_allow_blank_topCategory() {
         // given
         ItemInfoSearchRequest searchRequest = new ItemInfoSearchRequest(null, null, "");
+        when(itemInfoRepository.search(eq(searchRequest), any(Pageable.class))).thenReturn(List.of());
 
-        // when & then
-        assertThatThrownBy(() -> itemInfoService.findAllSummary(searchRequest, Sort.Direction.ASC))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ItemInfoExceptionCode.TOP_CATEGORY_REQUIRED.getMessage());
+        // when
+        List<ItemInfoSummaryResponse> result =
+                itemInfoService.findAllSummary(searchRequest, Sort.Direction.ASC);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(itemInfoRepository).search(eq(searchRequest), any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
## 📋 상세 설명

- ItemInfo 검색에서 topCategory 필수 검증 제거 및 관련 테스트/Swagger 설명 갱신
- 페이지 요청 DTO들의 size 제한(10~50) 및 toPageable()에서 size 보정(clamp) 로직 추가
- 실시간 경매장 정렬 기본값을 만료일시 DESC로 변경하고 정렬 필드 enum 명칭/문서 일부 수정


## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `이슈 미등록`