### PR TITLE
chore: 사용자 인증 메시지 카프카 로깅 추가

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +13,9 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.event.AuctionHistorySavedEvent;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.application.service;
 
 import jakarta.persistence.EntityManager;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -15,6 +14,8 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,8 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.OptionalInt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,6 +8,10 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +9,8 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.Instant;
-import java.util.List;
 import lombok.*;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
+
+import java.time.Instant;
+import java.util.List;
 
 @Entity
 @Table(name = "auction_history")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
@@ -1,7 +1,8 @@
 package until.the.eternity.auctionhistory.domain.event;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 /** 경매장 거래 내역 저장 완료 이벤트 AuctionHistoryScheduler가 거래 내역을 성공적으로 저장한 후 발행됩니다. */
 @Getter

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
+
+import java.util.List;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.time.Instant;
-import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,14 +1,15 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,9 +1,5 @@
 package until.the.eternity.auctionhistory.domain.service;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalInt;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,6 +7,11 @@ import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryReposit
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort.LatestDateWithIds;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,8 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,14 +1,15 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -8,11 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,6 +22,12 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.request.DateAuction
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
 import until.the.eternity.auctionitemoption.domain.entity.QAuctionHistoryItemOption;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,10 +1,6 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -15,6 +11,11 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,9 +2,10 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
+
 import java.time.Instant;
 import java.util.List;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 검색 기준 (이상/이하/같음) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 정렬 방향 (오름차순/내림차순) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.Instant;
 import java.util.List;
-import lombok.*;
 
 /** 실시간 경매장에서 판매 중인 아이템 정보. V15 마이그레이션에서 auction_item → auction_realtime_item으로 변경됨. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 /** 실시간 경매장 아이템(auction_realtime_item)에 연결된 아이템 옵션 정보. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionitemoption.domain.entity;
 
 import jakarta.persistence.*;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
+
+import java.util.UUID;
 
 /**
  * 경매장 거래 내역(auction_history)에 연결된 아이템 옵션 정보. V15 마이그레이션에서 auction_item_option →

--- a/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
@@ -1,8 +1,5 @@
 package until.the.eternity.auctionrealtime.application.scheduler;
 
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +11,10 @@ import until.the.eternity.auctionrealtime.application.service.fetcher.AuctionRea
 import until.the.eternity.auctionrealtime.application.service.persister.AuctionRealtimePersister;
 import until.the.eternity.auctionrealtime.domain.service.fetcher.AuctionRealtimeFetcherPort.FetchResult;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * 실시간 경매장 데이터 수집 스케줄러.

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service;
 
-import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -16,6 +14,9 @@ import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.AuctionRe
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeItemOptionResponse;
 import until.the.eternity.common.enums.ItemCategory;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.time.Instant;
+import java.util.List;
 
 /** 실시간 경매장 데이터 Service. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service.fetcher;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +8,9 @@ import until.the.eternity.auctionrealtime.infrastructure.client.AuctionRealtimeC
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeListResponse;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 실시간 경매장 데이터 Fetcher 구현체.

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service.persister;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,6 +8,8 @@ import until.the.eternity.auctionrealtime.domain.mapper.OpenApiAuctionRealtimeMa
 import until.the.eternity.auctionrealtime.domain.service.persister.AuctionRealtimePersisterPort;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Persister 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.AuctionRealtimeDetailResponse;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeItemOptionResponse;
+
+import java.util.List;
 
 /** AuctionRealtimeItem Entity to DTO mapper class. */
 @Mapper(componentModel = "spring")

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 /** OpenApiAuctionRealtimeResponse → AuctionRealtimeItem Entity 변환 Mapper. */
 @Mapper(componentModel = "spring", uses = OpenApiRealtimeItemOptionMapper.class)

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
@@ -1,13 +1,14 @@
 package until.the.eternity.auctionrealtime.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionRealtimeItem Repository Port (Hexagonal Architecture). */
 public interface AuctionRealtimeItemRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
@@ -1,8 +1,9 @@
 package until.the.eternity.auctionrealtime.domain.service.fetcher;
 
-import java.util.List;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Fetcher Port. */
 public interface AuctionRealtimeFetcherPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionrealtime.domain.service.persister;
 
-import java.util.List;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Persister Port. */
 public interface AuctionRealtimePersisterPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
-import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
+
+import java.time.Instant;
 
 /** AuctionRealtimeItem JPA Repository. */
 public interface AuctionRealtimeItemRepository extends JpaRepository<AuctionRealtimeItem, Long> {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
@@ -1,9 +1,6 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,6 +10,10 @@ import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.domain.repository.AuctionRealtimeItemRepositoryPort;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionRealtimeItemRepositoryPort 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -8,8 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -23,6 +21,9 @@ import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /** Nexon Open API /auction/list 응답 리스트 DTO. */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
@@ -2,9 +2,10 @@ package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
+
 import java.time.Instant;
 import java.util.List;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 /** Nexon Open API /auction/list 응답 DTO. 현재 경매장에서 판매 중인 아이템 정보. */
 public record OpenApiAuctionRealtimeResponse(

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionrealtime.interfaces.rest.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 실시간 경매장 정렬 필드 */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
@@ -2,8 +2,6 @@ package until.the.eternity.auctionsearchoption.application.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,6 +10,9 @@ import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionM
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionsearchoption.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "auction_search_option_metadata")

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
@@ -1,7 +1,8 @@
 package until.the.eternity.auctionsearchoption.domain.repository;
 
-import java.util.List;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+import java.util.List;
 
 public interface AuctionSearchOptionRepositoryPort {
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+import java.util.List;
 
 @Repository
 interface AuctionSearchOptionJpaRepository

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
@@ -2,7 +2,6 @@ package until.the.eternity.auctionsearchoption.interfaces.rest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.auctionsearchoption.application.service.AuctionSearchOptionService;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
 import until.the.eternity.common.response.ApiResponse;
+
+import java.util.List;
 
 @Tag(name = "Auction Search Option", description = "경매 검색 옵션 API")
 @RestController

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
@@ -2,6 +2,7 @@ package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 @Schema(description = "검색 조건 필드 메타데이터")

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Map;
 
 @Schema(description = "검색 옵션 메타데이터 응답")

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,11 +1,12 @@
 package until.the.eternity.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/common/enums/SortDirection.java
@@ -3,8 +3,9 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Arrays;
 import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
 
 /** 정렬 방향 (오름차순/내림차순) */
 @Schema(description = "정렬 방향", enumAsRef = true)

--- a/src/main/java/until/the/eternity/common/enums/SortField.java
+++ b/src/main/java/until/the/eternity/common/enums/SortField.java
@@ -3,6 +3,7 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 정렬 필드 */

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
+
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
+++ b/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
@@ -4,9 +4,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +15,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import until.the.eternity.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.common.util.IpAddressUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Gateway에서 전달한 인증 헤더(X-Auth-*)를 기반으로 Spring Security의 Authentication을 생성하는 필터

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,8 +1,9 @@
 package until.the.eternity.common.response;
 
-import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,6 +1,7 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/common/util/SegongOptionParser.java
+++ b/src/main/java/until/the/eternity/common/util/SegongOptionParser.java
@@ -1,8 +1,9 @@
 package until.the.eternity.common.util;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 세공 옵션의 option_value를 파싱하여 스킬명(option_value), 레벨(option_value2), 설명(option_desc)을 분리하는 유틸리티.

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,11 +1,12 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,10 +1,11 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
+
+import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,9 +2,10 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.application.runner;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -13,6 +12,8 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexService;
+
+import java.util.List;
 
 /**
  * 서버 재기동 시 DB 데이터를 Elasticsearch에 일괄 색인하는 Runner. application.yml에서

--- a/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.application.scheduler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.kafka.support.SendResult;
 import until.the.eternity.hornBugle.application.service.HornBugleService;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
@@ -129,13 +131,25 @@ public class HornBugleScheduler {
                                 history.getMessage(),
                                 history.getDateSend());
 
-                hornBugleKafkaProducerService.sendUserVerificationVerifyEvent(event);
+                CompletableFuture<SendResult<String, Object>> publishFuture =
+                        hornBugleKafkaProducerService.sendUserVerificationVerifyEvent(event);
 
-                log.info(
-                        "[HornBugle] Verification event published. characterName={}, serverName={}, verificationValue={}",
-                        history.getCharacterName(),
-                        history.getServerName(),
-                        verificationValue);
+                publishFuture.whenComplete(
+                        (result, ex) -> {
+                            if (ex == null && result != null) {
+                                log.info(
+                                        "[HornBugle] Verification event publish success. topic={}, partition={}, offset={}, payload={}",
+                                        result.getRecordMetadata().topic(),
+                                        result.getRecordMetadata().partition(),
+                                        result.getRecordMetadata().offset(),
+                                        event);
+                            } else {
+                                log.error(
+                                        "[HornBugle] Verification event publish failed. payload={}",
+                                        event,
+                                        ex);
+                            }
+                        });
             }
         }
     }

--- a/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
@@ -1,16 +1,11 @@
 package until.the.eternity.hornBugle.application.scheduler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.kafka.support.SendResult;
 import until.the.eternity.hornBugle.application.service.HornBugleService;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
@@ -19,6 +14,12 @@ import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHist
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.kafka.application.HornBugleKafkaProducerService;
 import until.the.eternity.hornBugle.kafka.dto.UserVerificationVerifyEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
@@ -1,8 +1,5 @@
 package until.the.eternity.hornBugle.application.service;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -18,6 +15,10 @@ import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexS
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,8 +1,9 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.Instant;
 import lombok.*;
+
+import java.time.Instant;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
@@ -1,10 +1,11 @@
 package until.the.eternity.hornBugle.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.domain.mapper;
 
-import java.time.Instant;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
@@ -8,6 +7,8 @@ import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleDocument;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
+
+import java.time.Instant;
 
 @Mapper(componentModel = "spring")
 public interface HornBugleMapper {

--- a/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
@@ -1,11 +1,12 @@
 package until.the.eternity.hornBugle.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 public interface HornBugleRepositoryPort {
 

--- a/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
@@ -1,10 +1,5 @@
 package until.the.eternity.hornBugle.domain.service;
 
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -12,6 +7,12 @@ import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +10,8 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
 
 @Document(indexName = "horn_bugle_world_history")
 @Setting(settingPath = "elasticsearch/horn-bugle-settings.json")

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
@@ -2,7 +2,6 @@ package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -17,6 +16,8 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Service;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
@@ -1,14 +1,15 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface HornBugleJpaRepository extends JpaRepository<HornBugleWorldHistory, Long> {

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
@@ -1,9 +1,6 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -12,6 +9,10 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OpenApiHornBugleHistoryListResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 
 public record OpenApiHornBugleHistoryResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
 @Schema(description = "뿔피리 히스토리 응답")

--- a/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
+++ b/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.kafka.application;
 
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -8,6 +7,8 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 import until.the.eternity.common.constant.KafkaTopicConstant;
 import until.the.eternity.hornBugle.kafka.dto.UserVerificationVerifyEvent;
+
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
+++ b/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
@@ -1,8 +1,10 @@
 package until.the.eternity.hornBugle.kafka.application;
 
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 import until.the.eternity.common.constant.KafkaTopicConstant;
 import until.the.eternity.hornBugle.kafka.dto.UserVerificationVerifyEvent;
@@ -19,7 +21,8 @@ public class HornBugleKafkaProducerService {
                     + "}")
     private String userVerificationVerifyTopic;
 
-    public void sendUserVerificationVerifyEvent(UserVerificationVerifyEvent event) {
-        kafkaTemplate.send(userVerificationVerifyTopic, event);
+    public CompletableFuture<SendResult<String, Object>> sendUserVerificationVerifyEvent(
+            UserVerificationVerifyEvent event) {
+        return kafkaTemplate.send(userVerificationVerifyTopic, event);
     }
 }

--- a/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
+++ b/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
@@ -1,9 +1,5 @@
 package until.the.eternity.iteminfo.application.service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -19,6 +15,11 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
@@ -2,8 +2,9 @@ package until.the.eternity.iteminfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.io.Serializable;
 import lombok.*;
+
+import java.io.Serializable;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
@@ -1,11 +1,11 @@
 package until.the.eternity.iteminfo.domain.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import until.the.eternity.common.exception.ExceptionCode;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
@@ -1,11 +1,12 @@
 package until.the.eternity.iteminfo.domain.repository;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 public interface ItemInfoRepositoryPort {
     List<ItemInfo> findAll();

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
@@ -1,11 +1,12 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
+
+import java.util.List;
 
 public interface ItemInfoJpaRepository
         extends JpaRepository<ItemInfo, ItemInfoId>, JpaSpecificationExecutor<ItemInfo> {

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
@@ -3,7 +3,6 @@ package until.the.eternity.iteminfo.infrastructure.persistence;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -12,6 +11,8 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.QItemInfo;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
@@ -1,6 +1,5 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +8,8 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +17,8 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/item-infos")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
@@ -1,11 +1,12 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @Schema(description = "아이템 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @Schema(description = "아이템 정보 요약 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
@@ -1,8 +1,9 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 @Schema(description = "아이템 정보 동기화 응답 DTO")

--- a/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.itemoptioninfo.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
@@ -2,11 +2,12 @@ package until.the.eternity.itemoptioninfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.io.Serializable;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.itemoptioninfo.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ItemOptionInfoRepositoryPort {
     List<ItemOptionInfo> findAll();

--- a/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
@@ -1,12 +1,13 @@
 package until.the.eternity.itemoptioninfo.infrastructure.persistence;
 
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
@@ -3,8 +3,6 @@ package until.the.eternity.itemoptioninfo.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +12,9 @@ import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.mapper.ItemOptionInfoMapper;
 import until.the.eternity.itemoptioninfo.interfaces.rest.dto.request.ItemOptionInfoRequest;
 import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/item-option-infos")

--- a/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.metalwareinfo.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoSyncResponse;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MetalwareInfoJpaRepository extends JpaRepository<MetalwareInfoEntity, String> {
 

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
@@ -2,7 +2,6 @@ package until.the.eternity.metalwareinfo.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.metalwareinfo.application.service.MetalwareInfoService;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoSyncResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/metalware-infos")

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Builder;
 
 @Builder
 @Schema(description = "세공 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +7,8 @@ import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +7,8 @@ import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
+++ b/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
@@ -1,5 +1,8 @@
 package until.the.eternity.ranking.domain.mapper;
 
+import org.springframework.stereotype.Component;
+import until.the.eternity.ranking.interfaces.rest.dto.response.*;
+
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -7,8 +10,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.springframework.stereotype.Component;
-import until.the.eternity.ranking.interfaces.rest.dto.response.*;
 
 @Component
 public class RankingMapper {

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.AllTimeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/all-time")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,8 @@ import until.the.eternity.ranking.application.service.CategoryRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.CategoryRankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/category")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,8 @@ import until.the.eternity.ranking.application.service.PriceChangeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/price-change")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.PriceRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/price")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.VolumeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/volume")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
 @Schema(description = "역대 기록 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 
 @Schema(description = "가격 변동 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 
 @Schema(description = "거래량 변동 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 

--- a/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
+++ b/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
@@ -1,10 +1,11 @@
 package until.the.eternity.ranking.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
+
+import java.util.List;
 
 public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
@@ -1,8 +1,9 @@
 package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "일간 통계 검색 요청")
 public record DailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "아이템별 일간 통계 검색 요청")
 public record ItemDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "아이템별 주간 통계 검색 요청")
 public record ItemWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "서브카테고리별 일간 통계 검색 요청")
 public record SubcategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "서브카테고리별 주간 통계 검색 요청")
 public record SubcategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "탑카테고리별 일간 통계 검색 요청")
 public record TopCategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "탑카테고리별 주간 통계 검색 요청")
 public record TopCategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
@@ -1,13 +1,14 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ItemDailyStatisticsRepository extends JpaRepository<ItemDailyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
@@ -1,13 +1,14 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.SubcategoryDailyStatistics;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SubcategoryDailyStatisticsRepository
         extends JpaRepository<SubcategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
@@ -1,13 +1,14 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.TopCategoryDailyStatistics;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TopCategoryDailyStatisticsRepository
         extends JpaRepository<TopCategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
@@ -1,12 +1,13 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.ItemWeeklyStatistics;
+
+import java.util.List;
 
 public interface ItemWeeklyStatisticsRepository extends JpaRepository<ItemWeeklyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
@@ -1,12 +1,13 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.SubcategoryWeeklyStatistics;
+
+import java.util.List;
 
 public interface SubcategoryWeeklyStatisticsRepository
         extends JpaRepository<SubcategoryWeeklyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
@@ -1,12 +1,13 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.TopCategoryWeeklyStatistics;
+
+import java.util.List;
 
 public interface TopCategoryWeeklyStatisticsRepository
         extends JpaRepository<TopCategoryWeeklyStatistics, Long> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,12 +80,12 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: true
+      enable-logging: false
 
 logging:
   config: classpath:logback/logback-display.xml
   level:
-    until.the.eternity: DEBUG
+    until.the.eternity: INFO
 
 openapi:
   nexon:

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -1,11 +1,5 @@
 package until.the.eternity.auctionhistory.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +20,13 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryServiceTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcherTest.java
@@ -1,13 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +13,15 @@ import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryCli
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryListResponse;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalInt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryFetcherTest {

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersisterTest.java
@@ -1,11 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +12,13 @@ import until.the.eternity.auctionhistory.domain.mapper.OpenApiAuctionHistoryMapp
 import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateChecker;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryPersisterTest {

--- a/src/test/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateCheckerTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateCheckerTest.java
@@ -1,13 +1,5 @@
 package until.the.eternity.auctionhistory.domain.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +11,15 @@ import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryReposit
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort.LatestDateWithIds;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryDuplicateCheckerTest {

--- a/src/test/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcherTest.java
+++ b/src/test/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcherTest.java
@@ -1,12 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service.fetcher;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
-import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +13,14 @@ import until.the.eternity.auctionrealtime.infrastructure.client.AuctionRealtimeC
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeListResponse;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionRealtimeFetcherTest {

--- a/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionServiceTest.java
@@ -1,11 +1,6 @@
 package until.the.eternity.auctionsearchoption.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +11,12 @@ import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionM
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionSearchOptionServiceTest {

--- a/src/test/java/until/the/eternity/common/util/SegongOptionParserTest.java
+++ b/src/test/java/until/the/eternity/common/util/SegongOptionParserTest.java
@@ -1,12 +1,12 @@
 package until.the.eternity.common.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SegongOptionParserTest {
 

--- a/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
+++ b/src/test/java/until/the/eternity/iteminfo/application/service/ItemInfoServiceTest.java
@@ -16,8 +16,10 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoServiceTest.java
+++ b/src/test/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoServiceTest.java
@@ -1,9 +1,5 @@
 package until.the.eternity.metalwareinfo.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +9,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoSyncResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MetalwareInfoServiceTest {


### PR DESCRIPTION
## 📋 상세 설명

- Kafka Producer가 CompletableFuture를 반환하도록 개선하여 메시지 발행 성공/실패 추적 및 상세 로깅 추가
- 로깅 설정 변경: p6spy 비활성화, 애플리케이션 로그 레벨 DEBUG → INFO 조정
  - 배치 특성상 p6spy 로깅을 활성화하니 너무 많은 로그가 발생함 

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요 `테스트 불필요`
- [x] 문서는 업데이트 되었나요 `문서 업데이트 불필요`
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `이슈 미등록`