### PR TITLE
feat: 경매장 검색 API 세공 요청 파라미터 추가

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -25,6 +25,7 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.enums.SearchStandar
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.DateAuctionBuyRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
+import until.the.eternity.auctionhistory.interfaces.rest.dto.request.MetalwareSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
 import until.the.eternity.auctionitemoption.domain.entity.QAuctionHistoryItemOption;
 
@@ -190,6 +191,32 @@ class AuctionHistoryQueryDslRepository {
                                                 .and(optSuffix.optionSubType.eq("접미"))
                                                 .and(optSuffix.optionValue.eq(enchantSuffix)));
                 builder.and(ah.auctionBuyId.in(subSuffix));
+            }
+        }
+
+        // 세공 검색 조건 (각 세공 이름마다 별도 서브쿼리, AND 조건)
+        if (c.metalwareSearchRequests() != null && !c.metalwareSearchRequests().isEmpty()) {
+            for (int i = 0; i < c.metalwareSearchRequests().size(); i++) {
+                MetalwareSearchRequest mw = c.metalwareSearchRequests().get(i);
+                if (mw.metalware() == null || mw.metalware().isBlank()) continue;
+
+                QAuctionHistoryItemOption mwOpt = new QAuctionHistoryItemOption("mw" + i);
+                NumberTemplate<Integer> mwLevel =
+                        Expressions.numberTemplate(
+                                Integer.class, "CAST({0} AS UNSIGNED)", mwOpt.optionValue2);
+
+                var mwSubQuery =
+                        JPAExpressions.select(mwOpt.auctionHistory.auctionBuyId)
+                                .from(mwOpt)
+                                .where(
+                                        mwOpt.optionType
+                                                .eq("세공 옵션")
+                                                .and(mwOpt.optionValue.eq(mw.metalware()))
+                                                .and(
+                                                        mwLevel.between(
+                                                                mw.resolvedLevelFrom(),
+                                                                mw.resolvedLevelTo())));
+                builder.and(ah.auctionBuyId.in(mwSubQuery));
             }
         }
 

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 /** 경매 히스토리 검색 조건 DTO - 페이지네이션 포함 */
 @Schema(description = "경매 거래내역 검색 조건")
@@ -17,4 +18,8 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "거래 일자 조건") DateAuctionBuyRequest dateAuctionBuyRequest,
         @Schema(description = "가격 검색 조건") PriceSearchRequest priceSearchRequest,
         @Schema(description = "아이템 옵션 검색 조건") ItemOptionSearchRequest itemOptionSearchRequest,
-        @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest) {}
+        @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
+        @Schema(
+                        description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/MetalwareSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/MetalwareSearchRequest.java
@@ -1,0 +1,19 @@
+package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세공 검색 조건")
+public record MetalwareSearchRequest(
+        @Schema(description = "세공 이름 (완전 일치)", example = "불의 연성술") String metalware,
+        @Schema(description = "세공 레벨 시작값 (null이면 1로 처리)", example = "1") Integer levelFrom,
+        @Schema(description = "세공 레벨 종료값 (null이면 30으로 처리)", example = "30")
+                Integer levelTo) {
+
+    public int resolvedLevelFrom() {
+        return levelFrom != null ? levelFrom : 1;
+    }
+
+    public int resolvedLevelTo() {
+        return levelTo != null ? levelTo : 30;
+    }
+}

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.enums.SearchStandard;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
+import until.the.eternity.auctionhistory.interfaces.rest.dto.request.MetalwareSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItem;
@@ -158,6 +159,32 @@ class AuctionRealtimeQueryDslRepository {
                                                 .and(optSuffix.optionSubType.eq("접미"))
                                                 .and(optSuffix.optionValue.eq(enchantSuffix)));
                 builder.and(ar.id.in(subSuffix));
+            }
+        }
+
+        // 세공 검색 조건 (각 세공 이름마다 별도 서브쿼리, AND 조건)
+        if (c.metalwareSearchRequests() != null && !c.metalwareSearchRequests().isEmpty()) {
+            for (int i = 0; i < c.metalwareSearchRequests().size(); i++) {
+                MetalwareSearchRequest mw = c.metalwareSearchRequests().get(i);
+                if (mw.metalware() == null || mw.metalware().isBlank()) continue;
+
+                QAuctionRealtimeItemOption mwOpt = new QAuctionRealtimeItemOption("mw" + i);
+                NumberTemplate<Integer> mwLevel =
+                        Expressions.numberTemplate(
+                                Integer.class, "CAST({0} AS UNSIGNED)", mwOpt.optionValue2);
+
+                var mwSubQuery =
+                        JPAExpressions.select(mwOpt.auctionRealtimeItem.id)
+                                .from(mwOpt)
+                                .where(
+                                        mwOpt.optionType
+                                                .eq("세공 옵션")
+                                                .and(mwOpt.optionValue.eq(mw.metalware()))
+                                                .and(
+                                                        mwLevel.between(
+                                                                mw.resolvedLevelFrom(),
+                                                                mw.resolvedLevelTo())));
+                builder.and(ar.id.in(mwSubQuery));
             }
         }
 

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
@@ -1,8 +1,10 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.EnchantSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
+import until.the.eternity.auctionhistory.interfaces.rest.dto.request.MetalwareSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
 
 /** 실시간 경매장 검색 조건 DTO */
@@ -19,4 +21,8 @@ public record AuctionRealtimeSearchRequest(
         @Schema(description = "소분류 카테고리", example = "검") String itemSubCategory,
         @Schema(description = "가격 검색 조건") PriceSearchRequest priceSearchRequest,
         @Schema(description = "아이템 옵션 검색 조건") ItemOptionSearchRequest itemOptionSearchRequest,
-        @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest) {}
+        @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
+        @Schema(
+                        description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -42,7 +42,7 @@ class AuctionHistoryServiceTest {
     void search_should_return_paged_response() {
         // given
         AuctionHistorySearchRequest searchRequest =
-                new AuctionHistorySearchRequest(null, null, null, null, null, null, null, null);
+                new AuctionHistorySearchRequest(null, null, null, null, null, null, null, null, null);
         PageRequestDto pageRequestDto = mock(PageRequestDto.class);
         Pageable pageable = PageRequest.of(0, 10);
         when(pageRequestDto.toPageable()).thenReturn(pageable);


### PR DESCRIPTION
## 📋 상세 설명

- 경매장 조회 API에 세공 요청 파라미터 추가
- 세공명, 검색 범위 (int 시작값, int 종료값)으로 이루어진 List를 받아 검색
- 검색 범위의 경우 시작값 기본값=1, 종료값 기본값=30으로 설정

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요