### PR TITLE
fix: auction search query dsl 오류 수정

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -203,7 +203,7 @@ class AuctionHistoryQueryDslRepository {
                 QAuctionHistoryItemOption mwOpt = new QAuctionHistoryItemOption("mw" + i);
                 NumberTemplate<Integer> mwLevel =
                         Expressions.numberTemplate(
-                                Integer.class, "CAST({0} AS UNSIGNED)", mwOpt.optionValue2);
+                                Integer.class, "CAST({0} AS integer)", mwOpt.optionValue2);
 
                 var mwSubQuery =
                         JPAExpressions.select(mwOpt.auctionHistory.auctionBuyId)

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -203,7 +203,7 @@ class AuctionHistoryQueryDslRepository {
                 QAuctionHistoryItemOption mwOpt = new QAuctionHistoryItemOption("mw" + i);
                 NumberTemplate<Integer> mwLevel =
                         Expressions.numberTemplate(
-                                Integer.class, "CAST({0} AS integer)", mwOpt.optionValue2);
+                                Integer.class, "CAST(NULLIF({0}, '') AS integer)", mwOpt.optionValue2);
 
                 var mwSubQuery =
                         JPAExpressions.select(mwOpt.auctionHistory.auctionBuyId)

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
@@ -1,12 +1,9 @@
 package until.the.eternity.auctionhistory.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import until.the.eternity.common.annotation.MetalwareParameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -32,17 +29,7 @@ public class AuctionHistoryController {
 
     @GetMapping("/search")
     @Operation(summary = "경매장 거래 내역 검색", description = "Nexon Open API 경매장 거래 내역 검색")
-    @Parameters({
-        @Parameter(name = "metalwareSearchRequests[0].metalware", description = "첫 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string", example = "불의 연성술")),
-        @Parameter(name = "metalwareSearchRequests[0].levelFrom", description = "첫 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "1")),
-        @Parameter(name = "metalwareSearchRequests[0].levelTo", description = "첫 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "30")),
-        @Parameter(name = "metalwareSearchRequests[1].metalware", description = "두 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
-        @Parameter(name = "metalwareSearchRequests[1].levelFrom", description = "두 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[1].levelTo", description = "두 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[2].metalware", description = "세 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
-        @Parameter(name = "metalwareSearchRequests[2].levelFrom", description = "세 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[2].levelTo", description = "세 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-    })
+    @MetalwareParameters
     public ResponseEntity<PageResponseDto<AuctionHistoryDetailResponse<ItemOptionResponse>>> search(
             @ParameterObject @ModelAttribute PageRequestDto pageDto,
             @ParameterObject @ModelAttribute @Valid AuctionHistorySearchRequest requestDto) {

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/controller/AuctionHistoryController.java
@@ -1,6 +1,10 @@
 package until.the.eternity.auctionhistory.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -28,6 +32,17 @@ public class AuctionHistoryController {
 
     @GetMapping("/search")
     @Operation(summary = "경매장 거래 내역 검색", description = "Nexon Open API 경매장 거래 내역 검색")
+    @Parameters({
+        @Parameter(name = "metalwareSearchRequests[0].metalware", description = "첫 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string", example = "불의 연성술")),
+        @Parameter(name = "metalwareSearchRequests[0].levelFrom", description = "첫 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "1")),
+        @Parameter(name = "metalwareSearchRequests[0].levelTo", description = "첫 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "30")),
+        @Parameter(name = "metalwareSearchRequests[1].metalware", description = "두 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
+        @Parameter(name = "metalwareSearchRequests[1].levelFrom", description = "두 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[1].levelTo", description = "두 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[2].metalware", description = "세 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
+        @Parameter(name = "metalwareSearchRequests[2].levelFrom", description = "세 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[2].levelTo", description = "세 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+    })
     public ResponseEntity<PageResponseDto<AuctionHistoryDetailResponse<ItemOptionResponse>>> search(
             @ParameterObject @ModelAttribute PageRequestDto pageDto,
             @ParameterObject @ModelAttribute @Valid AuctionHistorySearchRequest requestDto) {

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -7,8 +7,7 @@ import java.util.List;
 @Schema(description = "경매 거래내역 검색 조건")
 public record AuctionHistorySearchRequest(
         @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드") String itemName,
-        @Schema(
-                        description = "아이템 이름 완전 일치 검색 여부 (true: eq, false: like)",
+        @Schema(description = "아이템 이름 완전 일치 검색 여부 (true: eq, false: like)",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         defaultValue = "false",
                         example = "false")
@@ -19,8 +18,7 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "가격 검색 조건") PriceSearchRequest priceSearchRequest,
         @Schema(description = "아이템 옵션 검색 조건") ItemOptionSearchRequest itemOptionSearchRequest,
         @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
-        @Schema(
-                        description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
+        @Schema(description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         hidden = true)
                 List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -21,5 +21,6 @@ public record AuctionHistorySearchRequest(
         @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
         @Schema(
                         description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
-                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                        hidden = true)
                 List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -171,7 +171,7 @@ class AuctionRealtimeQueryDslRepository {
                 QAuctionRealtimeItemOption mwOpt = new QAuctionRealtimeItemOption("mw" + i);
                 NumberTemplate<Integer> mwLevel =
                         Expressions.numberTemplate(
-                                Integer.class, "CAST({0} AS UNSIGNED)", mwOpt.optionValue2);
+                                Integer.class, "CAST({0} AS integer)", mwOpt.optionValue2);
 
                 var mwSubQuery =
                         JPAExpressions.select(mwOpt.auctionRealtimeItem.id)

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -171,7 +171,9 @@ class AuctionRealtimeQueryDslRepository {
                 QAuctionRealtimeItemOption mwOpt = new QAuctionRealtimeItemOption("mw" + i);
                 NumberTemplate<Integer> mwLevel =
                         Expressions.numberTemplate(
-                                Integer.class, "CAST({0} AS integer)", mwOpt.optionValue2);
+                                Integer.class,
+                                "CAST(NULLIF({0}, '') AS integer)",
+                                mwOpt.optionValue2);
 
                 var mwSubQuery =
                         JPAExpressions.select(mwOpt.auctionRealtimeItem.id)

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/controller/AuctionRealtimeController.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/controller/AuctionRealtimeController.java
@@ -1,11 +1,8 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import until.the.eternity.common.annotation.MetalwareParameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -28,17 +25,7 @@ public class AuctionRealtimeController {
 
     @GetMapping("/search")
     @Operation(summary = "실시간 경매장 아이템 검색", description = "실시간 경매장에 등록된 아이템 검색")
-    @Parameters({
-        @Parameter(name = "metalwareSearchRequests[0].metalware", description = "첫 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string", example = "불의 연성술")),
-        @Parameter(name = "metalwareSearchRequests[0].levelFrom", description = "첫 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "1")),
-        @Parameter(name = "metalwareSearchRequests[0].levelTo", description = "첫 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "30")),
-        @Parameter(name = "metalwareSearchRequests[1].metalware", description = "두 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
-        @Parameter(name = "metalwareSearchRequests[1].levelFrom", description = "두 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[1].levelTo", description = "두 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[2].metalware", description = "세 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
-        @Parameter(name = "metalwareSearchRequests[2].levelFrom", description = "세 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-        @Parameter(name = "metalwareSearchRequests[2].levelTo", description = "세 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
-    })
+    @MetalwareParameters
     public ResponseEntity<
                     PageResponseDto<AuctionRealtimeDetailResponse<RealtimeItemOptionResponse>>>
             search(

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/controller/AuctionRealtimeController.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/controller/AuctionRealtimeController.java
@@ -1,6 +1,10 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +28,17 @@ public class AuctionRealtimeController {
 
     @GetMapping("/search")
     @Operation(summary = "실시간 경매장 아이템 검색", description = "실시간 경매장에 등록된 아이템 검색")
+    @Parameters({
+        @Parameter(name = "metalwareSearchRequests[0].metalware", description = "첫 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string", example = "불의 연성술")),
+        @Parameter(name = "metalwareSearchRequests[0].levelFrom", description = "첫 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "1")),
+        @Parameter(name = "metalwareSearchRequests[0].levelTo", description = "첫 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer", example = "30")),
+        @Parameter(name = "metalwareSearchRequests[1].metalware", description = "두 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
+        @Parameter(name = "metalwareSearchRequests[1].levelFrom", description = "두 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[1].levelTo", description = "두 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[2].metalware", description = "세 번째 세공 이름 (완전 일치)", in = ParameterIn.QUERY, schema = @Schema(type = "string")),
+        @Parameter(name = "metalwareSearchRequests[2].levelFrom", description = "세 번째 세공 레벨 시작값 (null이면 1로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+        @Parameter(name = "metalwareSearchRequests[2].levelTo", description = "세 번째 세공 레벨 종료값 (null이면 30으로 처리)", in = ParameterIn.QUERY, schema = @Schema(type = "integer")),
+    })
     public ResponseEntity<
                     PageResponseDto<AuctionRealtimeDetailResponse<RealtimeItemOptionResponse>>>
             search(

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
@@ -11,8 +11,7 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearch
 @Schema(description = "실시간 경매장 검색 조건")
 public record AuctionRealtimeSearchRequest(
         @Schema(description = "아이템 이름 (like 검색)", example = "페러시우스 타이탄 블레이드") String itemName,
-        @Schema(
-                        description = "아이템 이름 완전 일치 검색 여부 (true: eq, false: like)",
+        @Schema(description = "아이템 이름 완전 일치 검색 여부 (true: eq, false: like)",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         defaultValue = "false",
                         example = "false")
@@ -22,8 +21,7 @@ public record AuctionRealtimeSearchRequest(
         @Schema(description = "가격 검색 조건") PriceSearchRequest priceSearchRequest,
         @Schema(description = "아이템 옵션 검색 조건") ItemOptionSearchRequest itemOptionSearchRequest,
         @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
-        @Schema(
-                        description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
+        @Schema(description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         hidden = true)
                 List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
@@ -24,5 +24,6 @@ public record AuctionRealtimeSearchRequest(
         @Schema(description = "인챈트 검색 조건") EnchantSearchRequest enchantSearchRequest,
         @Schema(
                         description = "세공 검색 조건 목록 (최대 3개, AND 조건으로 검색)",
-                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                        hidden = true)
                 List<MetalwareSearchRequest> metalwareSearchRequests) {}

--- a/src/main/java/until/the/eternity/common/annotation/MetalwareParameters.java
+++ b/src/main/java/until/the/eternity/common/annotation/MetalwareParameters.java
@@ -1,0 +1,59 @@
+package until.the.eternity.common.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Parameters({
+    @Parameter(
+            name = "metalwareSearchRequests[0].metalware",
+            description = "첫 번째 세공 이름 (완전 일치)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "string", example = "불의 연성술")),
+    @Parameter(
+            name = "metalwareSearchRequests[0].levelFrom",
+            description = "첫 번째 세공 레벨 시작값 (null이면 1로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer", example = "1")),
+    @Parameter(
+            name = "metalwareSearchRequests[0].levelTo",
+            description = "첫 번째 세공 레벨 종료값 (null이면 30으로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer", example = "30")),
+    @Parameter(
+            name = "metalwareSearchRequests[1].metalware",
+            description = "두 번째 세공 이름 (완전 일치)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "string")),
+    @Parameter(
+            name = "metalwareSearchRequests[1].levelFrom",
+            description = "두 번째 세공 레벨 시작값 (null이면 1로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer")),
+    @Parameter(
+            name = "metalwareSearchRequests[1].levelTo",
+            description = "두 번째 세공 레벨 종료값 (null이면 30으로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer")),
+    @Parameter(
+            name = "metalwareSearchRequests[2].metalware",
+            description = "세 번째 세공 이름 (완전 일치)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "string")),
+    @Parameter(
+            name = "metalwareSearchRequests[2].levelFrom",
+            description = "세 번째 세공 레벨 시작값 (null이면 1로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer")),
+    @Parameter(
+            name = "metalwareSearchRequests[2].levelTo",
+            description = "세 번째 세공 레벨 종료값 (null이면 30으로 처리)",
+            in = ParameterIn.QUERY,
+            schema = @Schema(type = "integer")),
+})
+public @interface MetalwareParameters {}


### PR DESCRIPTION
## 📋 상세 설명

- QueryDSL 기반 경매 검색에서 세공(메탈웨어) 레벨 필터링 시 사용되는 CAST 구문을 수정하여 DB 타입 변환 오류 해결
- 실시간 경매 검색 QueryDSL에서 CAST(... AS UNSIGNED) → CAST(... AS integer)로 변경
- 거래내역 검색 QueryDSL에서 CAST(... AS UNSIGNED) → CAST(... AS integer)로 변경

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요
