### PR TITLE
perf: 경매장 테이블 기본 정렬 조건을 단일 인덱스로 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,7 +80,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: false
+      enable-logging: true
 
 logging:
   config: classpath:logback/logback-display.xml

--- a/src/main/resources/db/migration/V26_create_index_on_auction_tables.sql
+++ b/src/main/resources/db/migration/V26_create_index_on_auction_tables.sql
@@ -1,0 +1,15 @@
+-- 검색 필터 없이 검색 시 사용되는 기본 검색 속도 보장 인덱스
+CREATE INDEX idx_ah_date_auction_buy
+    ON auction_history (date_auction_buy);
+
+-- 검색 필터 없이 검색 시 사용되는 기본 검색 속도 보장 인덱스
+CREATE INDEX idx_ah_auction_price_per_unit
+    ON auction_history (auction_price_per_unit);
+
+-- 검색 필터 없이 검색 시 사용되는 기본 검색 속도 보장 인덱스
+CREATE INDEX idx_ar_date_auction_expire
+    ON auction_realtime_item (date_auction_expire);
+
+-- 검색 필터 없이 검색 시 사용되는 기본 검색 속도 보장 인덱스
+CREATE INDEX idx_ar_auction_price_per_unit
+    ON auction_realtime_item (auction_price_per_unit);


### PR DESCRIPTION
## 📋 상세 설명

- 경매장 테이블 기본 정렬 조건을 단일 인덱스로 추가
  - auction_history (date_auction_buy)
  - auction_history (auction_price_per_unit)
  - auction_realtime_item (date_auction_expire)
  - auction_realtime_item (auction_price_per_unit) 

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요