### PR TITLE
fix: p6spy enable logging false 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,7 +80,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: true
+      enable-logging: false
 
 logging:
   config: classpath:logback/logback-display.xml


### PR DESCRIPTION
## 📋 상세 설명

- p6spy enable logging false 설정
  - 테스트를 위해 true해두었다가 이전 pr에서 실수로 반영해버림 
 
## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요