### PR TITLE
feat: redis cache prefix version

### DIFF
--- a/src/main/java/until/the/eternity/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/config/RedisConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.CacheErrorHandler;
@@ -25,6 +26,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class RedisConfig implements CachingConfigurer {
 
+    @Value("${app.cache.redis-prefix:oab:v2}")
+    private String cacheKeyPrefix;
+
     @Override
     public CacheErrorHandler errorHandler() {
         return new RedisCacheErrorHandler();
@@ -38,7 +42,7 @@ public class RedisConfig implements CachingConfigurer {
                         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.activateDefaultTyping(
                 LaissezFaireSubTypeValidator.instance,
-                DefaultTyping.NON_FINAL,
+                DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY);
 
         GenericJackson2JsonRedisSerializer jsonSerializer =
@@ -46,6 +50,7 @@ public class RedisConfig implements CachingConfigurer {
 
         RedisCacheConfiguration defaultConfig =
                 RedisCacheConfiguration.defaultCacheConfig()
+                        .computePrefixWith(cacheName -> cacheKeyPrefix + ":" + cacheName + "::")
                         .entryTtl(Duration.ofMinutes(10))
                         .serializeKeysWith(
                                 RedisSerializationContext.SerializationPair.fromSerializer(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,7 +97,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: false
+      enable-logging: true
 
 logging:
   config: classpath:logback/logback-display.xml
@@ -146,6 +146,7 @@ elasticsearch:
 
 app:
   cache:
+    redis-prefix: ${APP_CACHE_REDIS_PREFIX:oab:v2} # 직렬화 방식 변경 시 버전업 필요
     warmup:
       enabled: ${APP_CACHE_WARMUP_ENABLED:true}
       ranking-limit: ${APP_CACHE_WARMUP_RANKING_LIMIT:50}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,7 +97,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: true
+      enable-logging: false
 
 logging:
   config: classpath:logback/logback-display.xml


### PR DESCRIPTION
## 📋 상세 설명

- `app.cache.redis-prefix` 설정을 도입하고, 이를 Spring Cache Redis 키 prefix에 적용
- Redis 캐시 값(value) 직렬화 타입 설정을 수정
- `application.yml`에서 P6Spy 로깅을 활성화

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요