### PR TITLE
feat: auction history count 전용 캐시 추가

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryCacheWarmupService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryCacheWarmupService.java
@@ -56,12 +56,14 @@ public class AuctionHistoryCacheWarmupService {
 
     private void evictCaches() {
         clearCache(CacheNames.AUCTION_HISTORY_SEARCH);
+        clearCache(CacheNames.AUCTION_HISTORY_COUNT);
         // auction_history 전체를 직접 쿼리하는 역대 랭킹도 함께 무효화
         clearCache(CacheNames.RANKING_ALLTIME_HIGHEST);
         clearCache(CacheNames.RANKING_ALLTIME_MONTH_VOLUME);
         log.info(
-                "[Cache Warmup] Evicted: {}, {}, {}",
+                "[Cache Warmup] Evicted: {}, {}, {}, {}",
                 CacheNames.AUCTION_HISTORY_SEARCH,
+                CacheNames.AUCTION_HISTORY_COUNT,
                 CacheNames.RANKING_ALLTIME_HIGHEST,
                 CacheNames.RANKING_ALLTIME_MONTH_VOLUME);
     }

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -4,8 +4,12 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
@@ -16,6 +20,7 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+import until.the.eternity.common.util.CacheKeyBuilder;
 import until.the.eternity.config.CacheNames;
 
 @Service
@@ -26,6 +31,7 @@ public class AuctionHistoryService {
     private final AuctionHistoryRepositoryPort repository;
     private final AuctionHistoryMapper mapper;
     private final EntityManager entityManager;
+    private final CacheManager cacheManager;
 
     /**
      * 경매 거래 내역을 검색한다.
@@ -46,9 +52,41 @@ public class AuctionHistoryService {
     public PageResponseDto<AuctionHistoryDetailResponse<ItemOptionResponse>> search(
             AuctionHistorySearchRequest requestDto, PageRequestDto pageRequestDto) {
 
-        Page<AuctionHistory> page = repository.search(requestDto, pageRequestDto.toPageable());
+        Pageable pageable = pageRequestDto.toPageable();
+        List<AuctionHistory> content = repository.searchContent(requestDto, pageable);
+        long total = resolveTotalCount(requestDto);
+        Page<AuctionHistory> page = new PageImpl<>(content, pageable, total);
         Page<AuctionHistoryDetailResponse<ItemOptionResponse>> dtoPage = page.map(mapper::toDto);
         return PageResponseDto.of(dtoPage);
+    }
+
+    private long resolveTotalCount(AuctionHistorySearchRequest requestDto) {
+        if (!isCountCacheEligible(requestDto)) {
+            return repository.count(requestDto);
+        }
+
+        Cache cache = cacheManager.getCache(CacheNames.AUCTION_HISTORY_COUNT);
+        if (cache == null) {
+            return repository.count(requestDto);
+        }
+
+        String cacheKey = CacheKeyBuilder.buildAuctionHistoryCountKey(requestDto);
+        Long cachedCount = cache.get(cacheKey, Long.class);
+        if (cachedCount != null) {
+            return cachedCount;
+        }
+
+        long total = repository.count(requestDto);
+        cache.put(cacheKey, total);
+        return total;
+    }
+
+    private boolean isCountCacheEligible(AuctionHistorySearchRequest requestDto) {
+        return requestDto.itemOptionSearchRequest() == null
+                && requestDto.enchantSearchRequest() == null
+                && (requestDto.metalwareSearchRequests() == null
+                        || requestDto.metalwareSearchRequests().isEmpty())
+                && requestDto.priceSearchRequest() == null;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
@@ -15,7 +14,9 @@ public interface AuctionHistoryRepositoryPort {
 
     record LatestDateWithIds(Instant latestDate, Set<String> existingIds) {}
 
-    Page<AuctionHistory> search(AuctionHistorySearchRequest condition, Pageable pageable);
+    List<AuctionHistory> searchContent(AuctionHistorySearchRequest condition, Pageable pageable);
+
+    long count(AuctionHistorySearchRequest condition);
 
     Optional<AuctionHistory> findById(String id);
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -14,8 +14,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
@@ -34,11 +32,51 @@ class AuctionHistoryQueryDslRepository {
     /** 옵션 조건 빌드 결과 (조건 BooleanBuilder + 추가된 조건 개수) */
     record OptionConditionResult(BooleanBuilder builder, int count) {}
 
-    /** 경매 거래내역 검색 (옵션 조건 포함) */
-    public Page<AuctionHistory> search(AuctionHistorySearchRequest condition, Pageable pageable) {
+    /** 경매 거래내역 콘텐츠 조회 (옵션 조건 포함) */
+    public List<AuctionHistory> searchContent(
+            AuctionHistorySearchRequest condition, Pageable pageable) {
         QAuctionHistory ah = QAuctionHistory.auctionHistory;
         QAuctionHistoryItemOption aio = QAuctionHistoryItemOption.auctionHistoryItemOption;
+        BooleanBuilder historyBuilder = buildSearchPredicate(condition, ah);
 
+        List<OrderSpecifier<?>> orderSpecifiers = buildOrderSpecifiers(pageable, ah);
+
+        // Deferred Join (Late Row Lookup): 인덱스 친화적으로 ID 먼저 조회
+        List<String> ids =
+                queryFactory
+                        .select(ah.auctionBuyId)
+                        .from(ah)
+                        .where(historyBuilder)
+                        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .selectFrom(ah)
+                .leftJoin(ah.auctionHistoryItemOptions, aio)
+                .fetchJoin()
+                .where(ah.auctionBuyId.in(ids))
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .distinct()
+                .fetch();
+    }
+
+    /** 경매 거래내역 조건 기준 전체 건수 조회 */
+    public long count(AuctionHistorySearchRequest condition) {
+        QAuctionHistory ah = QAuctionHistory.auctionHistory;
+        BooleanBuilder historyBuilder = buildSearchPredicate(condition, ah);
+        Long total = queryFactory.select(ah.count()).from(ah).where(historyBuilder).fetchOne();
+        return total == null ? 0L : total;
+    }
+
+    /** 검색 where 절 빌드 (옵션/인챈트/세공 포함) */
+    private BooleanBuilder buildSearchPredicate(
+            AuctionHistorySearchRequest condition, QAuctionHistory ah) {
         OptionConditionResult optionResult = buildOptionConditionResult(condition);
         boolean hasItemOptionFilter = hasEffectiveItemOptionFilter(optionResult);
         boolean hasEnchantFilter = hasEnchantFilter(condition);
@@ -46,10 +84,8 @@ class AuctionHistoryQueryDslRepository {
         boolean isBasicSearchOnly =
                 !(hasItemOptionFilter || hasEnchantFilter || hasMetalwareFilter);
 
-        // 1단계: 거래내역 조건 빌드
         BooleanBuilder historyBuilder = buildHistoryPredicate(condition, ah, !isBasicSearchOnly);
 
-        // 2단계: 옵션 조건이 있으면 서브쿼리 추가
         if (hasItemOptionFilter) {
             QAuctionHistoryItemOption subOption = new QAuctionHistoryItemOption("subOption");
             var subQuery =
@@ -62,41 +98,7 @@ class AuctionHistoryQueryDslRepository {
             historyBuilder.and(ah.auctionBuyId.in(subQuery));
         }
 
-        // 3단계: 정렬 조건 빌드
-        List<OrderSpecifier<?>> orderSpecifiers = buildOrderSpecifiers(pageable, ah);
-
-        // 4단계: Deferred Join (Late Row Lookup) 패턴 적용
-        // 4-1단계: ID만 먼저 조회 (인덱스 활용)
-        List<String> ids =
-                queryFactory
-                        .select(ah.auctionBuyId)
-                        .from(ah)
-                        .where(historyBuilder)
-                        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
-                        .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize())
-                        .fetch();
-
-        // 결과가 없으면 빈 페이지 반환
-        if (ids.isEmpty()) {
-            return new PageImpl<>(List.of(), pageable, 0L);
-        }
-
-        // 4-2단계: ID로 상세 조회 (LEFT JOIN으로 옵션 포함)
-        List<AuctionHistory> content =
-                queryFactory
-                        .selectFrom(ah)
-                        .leftJoin(ah.auctionHistoryItemOptions, aio)
-                        .fetchJoin()
-                        .where(ah.auctionBuyId.in(ids))
-                        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
-                        .distinct()
-                        .fetch();
-
-        // Count 쿼리 (JOIN 없이 실행)
-        Long total = queryFactory.select(ah.count()).from(ah).where(historyBuilder).fetchOne();
-
-        return new PageImpl<>(content, pageable, total == null ? 0L : total);
+        return historyBuilder;
     }
 
     /** 거래내역 기본 조건 빌드 (카테고리, 아이템명, 가격, 거래일자) */

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +28,14 @@ public class AuctionHistoryRepositoryPortImpl implements AuctionHistoryRepositor
     private int batchSize;
 
     @Override
-    public Page<AuctionHistory> search(AuctionHistorySearchRequest condition, Pageable pageable) {
-        return queryDslRepository.search(condition, pageable);
+    public List<AuctionHistory> searchContent(
+            AuctionHistorySearchRequest condition, Pageable pageable) {
+        return queryDslRepository.searchContent(condition, pageable);
+    }
+
+    @Override
+    public long count(AuctionHistorySearchRequest condition) {
+        return queryDslRepository.count(condition);
     }
 
     @Override

--- a/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
+++ b/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
@@ -114,12 +114,9 @@ public final class CacheKeyBuilder {
     public static String buildAuctionHistorySearchKey(
             AuctionHistorySearchRequest requestDto, PageRequestDto pageRequestDto) {
         Pageable pageable = pageRequestDto.toPageable();
-        String dateFrom = "";
-        String dateTo = "";
-        if (requestDto.dateAuctionBuyRequest() != null) {
-            dateFrom = normalize(requestDto.dateAuctionBuyRequest().dateAuctionBuyFrom());
-            dateTo = normalize(requestDto.dateAuctionBuyRequest().dateAuctionBuyTo());
-        }
+        String[] dateRange = resolveAuctionHistoryDateRange(requestDto);
+        String dateFrom = dateRange[0];
+        String dateTo = dateRange[1];
 
         return pageable.getPageNumber()
                 + ":"
@@ -128,6 +125,24 @@ public final class CacheKeyBuilder {
                 + pageable.getSort()
                 + ":"
                 + normalize(requestDto.itemName())
+                + ":"
+                + isExactItemName(requestDto.isExactItemName())
+                + ":"
+                + normalize(requestDto.itemTopCategory())
+                + ":"
+                + normalize(requestDto.itemSubCategory())
+                + ":"
+                + dateFrom
+                + ":"
+                + dateTo;
+    }
+
+    public static String buildAuctionHistoryCountKey(AuctionHistorySearchRequest requestDto) {
+        String[] dateRange = resolveAuctionHistoryDateRange(requestDto);
+        String dateFrom = dateRange[0];
+        String dateTo = dateRange[1];
+
+        return normalize(requestDto.itemName())
                 + ":"
                 + isExactItemName(requestDto.isExactItemName())
                 + ":"
@@ -174,6 +189,16 @@ public final class CacheKeyBuilder {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? "" : trimmed;
+    }
+
+    private static String[] resolveAuctionHistoryDateRange(AuctionHistorySearchRequest requestDto) {
+        String dateFrom = "";
+        String dateTo = "";
+        if (requestDto.dateAuctionBuyRequest() != null) {
+            dateFrom = normalize(requestDto.dateAuctionBuyRequest().dateAuctionBuyFrom());
+            dateTo = normalize(requestDto.dateAuctionBuyRequest().dateAuctionBuyTo());
+        }
+        return new String[] {dateFrom, dateTo};
     }
 
     private static boolean isExactItemName(Boolean isExactItemName) {

--- a/src/main/java/until/the/eternity/config/CacheNames.java
+++ b/src/main/java/until/the/eternity/config/CacheNames.java
@@ -52,4 +52,5 @@ public final class CacheNames {
 
     // ===== 경매 거래 내역 =====
     public static final String AUCTION_HISTORY_SEARCH = "auction-history:search";
+    public static final String AUCTION_HISTORY_COUNT = "auction-history:count";
 }

--- a/src/main/java/until/the/eternity/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/config/RedisConfig.java
@@ -110,6 +110,7 @@ public class RedisConfig implements CachingConfigurer {
 
         // 경매 거래 내역 - 2시간 TTL (배치 완료 시 evict + warmup)
         configs.put(CacheNames.AUCTION_HISTORY_SEARCH, defaultConfig.entryTtl(Duration.ofHours(2)));
+        configs.put(CacheNames.AUCTION_HISTORY_COUNT, defaultConfig.entryTtl(Duration.ofHours(2)));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,7 +97,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: true
+      enable-logging: false
 
 logging:
   config: classpath:logback/logback-display.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,7 +97,7 @@ springdoc:
 decorator:
   datasource:
     p6spy:
-      enable-logging: false
+      enable-logging: true
 
 logging:
   config: classpath:logback/logback-display.xml

--- a/src/main/resources/db/migration/V27__add_auction_history_category_date_index.sql
+++ b/src/main/resources/db/migration/V27__add_auction_history_category_date_index.sql
@@ -1,0 +1,5 @@
+-- 카테고리 + 거래일자 범위 검색/카운트 최적화
+-- 기존 idx_ah_top_sub_name_date는 item_name이 중간 컬럼이라
+-- item_name 조건이 없는 top/sub/date 질의에서 비효율이 발생할 수 있음
+CREATE INDEX idx_ah_top_sub_date
+    ON auction_history (item_top_category, item_sub_category, date_auction_buy DESC);

--- a/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
+++ b/src/test/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryServiceTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.application.service.persister.AuctionHistoryPersister;
@@ -26,6 +25,7 @@ import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHis
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
+import until.the.eternity.config.CacheNames;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionHistoryServiceTest {
@@ -34,6 +34,7 @@ class AuctionHistoryServiceTest {
     @Mock private AuctionHistoryFetcherPort fetcherPort;
     @Mock private AuctionHistoryPersister persister;
     @Mock private AuctionHistoryMapper mapper;
+    @Mock private CacheManager cacheManager;
 
     @InjectMocks private AuctionHistoryService service;
 
@@ -51,9 +52,10 @@ class AuctionHistoryServiceTest {
         AuctionHistory entity = new AuctionHistory();
         AuctionHistoryDetailResponse<ItemOptionResponse> detailDto =
                 mock(AuctionHistoryDetailResponse.class);
-        Page<AuctionHistory> entityPage = new PageImpl<>(List.of(entity), pageable, 1);
 
-        when(repositoryPort.search(searchRequest, pageable)).thenReturn(entityPage);
+        when(cacheManager.getCache(CacheNames.AUCTION_HISTORY_COUNT)).thenReturn(null);
+        when(repositoryPort.searchContent(searchRequest, pageable)).thenReturn(List.of(entity));
+        when(repositoryPort.count(searchRequest)).thenReturn(1L);
         when(mapper.toDto(entity)).thenReturn(detailDto);
 
         // when
@@ -62,7 +64,8 @@ class AuctionHistoryServiceTest {
 
         // then
         assertThat(result.items()).hasSize(1).contains(detailDto);
-        verify(repositoryPort).search(searchRequest, pageable);
+        verify(repositoryPort).searchContent(searchRequest, pageable);
+        verify(repositoryPort).count(searchRequest);
         verify(mapper).toDto(entity);
     }
 


### PR DESCRIPTION
## 📋 상세 설명

- 경매 기록 Repository의 search(Page) 메서드를 searchContent(List)와 count(long)으로 분리
  - 이를 통해 auction-history:count Redis 캐시를 사용하여 count 결과를 독립적으로 캐싱할 수 있도록 변경
- **새로운 DB 인덱스 idx_ah_top_sub_date**를 추가했습니다.
  - (item_top_category, item_sub_category, date_auction_buy DESC) 
  - item_name 필터가 없는 count/search 쿼리를 최적화하기 위한 인덱스입니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `이슈 미등록`