### PR TITLE
perf: 조회 API 성능 개선을 위한 캐싱 추가 적용 및 인덱스 추가

### DIFF
--- a/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/scheduler/AuctionHistoryScheduler.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionhistory.application.scheduler;
 
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +16,9 @@ import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionH
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.common.annotation.BatchLog;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryCacheWarmupService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryCacheWarmupService.java
@@ -10,6 +10,8 @@ import until.the.eternity.common.enums.SortDirection;
 import until.the.eternity.common.enums.SortField;
 import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.config.CacheNames;
+import until.the.eternity.ranking.application.service.AllTimeRankingService;
+import until.the.eternity.ranking.util.RankingConstants;
 
 /**
  * 경매 거래 내역 캐시 워밍업 서비스.
@@ -29,8 +31,10 @@ public class AuctionHistoryCacheWarmupService {
 
     private static final int WARMUP_SIZE = 20;
     private static final int WARMUP_MAX_PAGE = 2;
+    private static final int[] RANKING_WARMUP_LIMITS = {20, RankingConstants.DEFAULT_LIMIT};
 
     private final AuctionHistoryService auctionHistoryService;
+    private final AllTimeRankingService allTimeRankingService;
     private final CacheManager cacheManager;
 
     /**
@@ -41,6 +45,7 @@ public class AuctionHistoryCacheWarmupService {
     public void evictAndWarm() {
         evictCaches();
         warmup();
+        warmAllTimeRankingCaches();
     }
 
     /** 앱 시작 시 기본 화면 1개 키만 경량 워밍업한다. */
@@ -103,6 +108,27 @@ public class AuctionHistoryCacheWarmupService {
                 successCount,
                 failCount,
                 WARMUP_MAX_PAGE * SortField.values().length * SortDirection.values().length);
+    }
+
+    private void warmAllTimeRankingCaches() {
+        int successCount = 0;
+        int failCount = 0;
+
+        for (int limit : RANKING_WARMUP_LIMITS) {
+            try {
+                allTimeRankingService.getAllTimeHighestPrice(limit);
+                allTimeRankingService.getMonthLargestVolume(limit);
+                successCount += 2;
+            } catch (Exception e) {
+                failCount++;
+                log.warn("[Cache Warmup] Failed all-time ranking warmup: limit={}", limit, e);
+            }
+        }
+
+        log.info(
+                "[Cache Warmup] All-time ranking completed: success={}, fail={}",
+                successCount,
+                failCount);
     }
 
     private void clearCache(String cacheName) {

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -1,7 +1,6 @@
 package until.the.eternity.auctionhistory.application.service;
 
 import jakarta.persistence.EntityManager;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -22,6 +21,8 @@ import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.common.response.PageResponseDto;
 import until.the.eternity.common.util.CacheKeyBuilder;
 import until.the.eternity.config.CacheNames;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/AuctionHistoryService.java
@@ -47,7 +47,8 @@ public class AuctionHistoryService {
                     "#requestDto.itemOptionSearchRequest() == null"
                             + " and #requestDto.enchantSearchRequest() == null"
                             + " and (#requestDto.metalwareSearchRequests() == null or #requestDto.metalwareSearchRequests().isEmpty())"
-                            + " and #requestDto.priceSearchRequest() == null")
+                            + " and #requestDto.priceSearchRequest() == null",
+            sync = true)
     @Transactional(readOnly = true)
     public PageResponseDto<AuctionHistoryDetailResponse<ItemOptionResponse>> search(
             AuctionHistorySearchRequest requestDto, PageRequestDto pageRequestDto) {

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/fetcher/AuctionHistoryFetcher.java
@@ -1,8 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.fetcher;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.OptionalInt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,6 +8,10 @@ import until.the.eternity.auctionhistory.domain.service.fetcher.AuctionHistoryFe
 import until.the.eternity.auctionhistory.infrastructure.client.AuctionHistoryClient;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
+++ b/src/main/java/until/the/eternity/auctionhistory/application/service/persister/AuctionHistoryPersister.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionhistory.application.service.persister;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +9,8 @@ import until.the.eternity.auctionhistory.domain.service.AuctionHistoryDuplicateC
 import until.the.eternity.auctionhistory.domain.service.persister.AuctionHistoryPersisterPort;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/entity/AuctionHistory.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionhistory.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.Instant;
-import java.util.List;
 import lombok.*;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
+
+import java.time.Instant;
+import java.util.List;
 
 @Entity
 @Table(name = "auction_history")

--- a/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/event/AuctionHistorySavedEvent.java
@@ -1,7 +1,8 @@
 package until.the.eternity.auctionhistory.domain.event;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 /** 경매장 거래 내역 저장 완료 이벤트 AuctionHistoryScheduler가 거래 내역을 성공적으로 저장한 후 발행됩니다. */
 @Getter

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/AuctionHistoryMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.AuctionHistoryDetailResponse;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.response.ItemOptionResponse;
 import until.the.eternity.auctionitemoption.domain.entity.AuctionHistoryItemOption;
+
+import java.util.List;
 
 /**
  * AuctionHistory Entity to internal.responseDto transfer mapper class 데이터 흐름은 external.responseDto

--- a/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/mapper/OpenApiAuctionHistoryMapper.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionhistory.domain.mapper;
 
-import java.time.Instant;
-import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
 
 @Mapper(componentModel = "spring", uses = OpenApiItemOptionMapper.class)
 public interface OpenApiAuctionHistoryMapper {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/repository/AuctionHistoryRepositoryPort.java
@@ -1,13 +1,14 @@
 package until.the.eternity.auctionhistory.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /** 경매장 거래 내역 POJO Repository - Mock 또는 Stub 으로 대체해 단위 테스트 용이성 확보 */
 public interface AuctionHistoryRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/AuctionHistoryDuplicateChecker.java
@@ -1,9 +1,5 @@
 package until.the.eternity.auctionhistory.domain.service;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.OptionalInt;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,6 +7,11 @@ import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryReposit
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort.LatestDateWithIds;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/fetcher/AuctionHistoryFetcherPort.java
@@ -1,8 +1,9 @@
 package until.the.eternity.auctionhistory.domain.service.fetcher;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryFetcherPort {
     List<OpenApiAuctionHistoryResponse> fetch(ItemCategory category);

--- a/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionhistory/domain/service/persister/AuctionHistoryPersisterPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionhistory.domain.service.persister;
 
-import java.util.List;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.external.dto.OpenApiAuctionHistoryResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 public interface AuctionHistoryPersisterPort {
 

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryJpaRepository.java
@@ -1,14 +1,15 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AuctionHistoryJpaRepository

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryQueryDslRepository.java
@@ -8,11 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,6 +17,12 @@ import until.the.eternity.auctionhistory.domain.entity.QAuctionHistory;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.enums.SearchStandard;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.*;
 import until.the.eternity.auctionitemoption.domain.entity.QAuctionHistoryItemOption;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionhistory/infrastructure/persistence/AuctionHistoryRepositoryPortImpl.java
@@ -1,10 +1,6 @@
 package until.the.eternity.auctionhistory.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +10,11 @@ import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
 import until.the.eternity.auctionhistory.domain.repository.AuctionHistoryRepositoryPort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionHistoryRepository Interface 구현체 */
 @Repository

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OpenApiAuctionHistoryListResponse(

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/external/dto/OpenApiAuctionHistoryResponse.java
@@ -2,9 +2,10 @@ package until.the.eternity.auctionhistory.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
+
 import java.time.Instant;
 import java.util.List;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 public record OpenApiAuctionHistoryResponse(
         @JsonProperty("item_name") String itemName,

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SearchStandard.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 검색 기준 (이상/이하/같음) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/enums/SortDirection.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionhistory.interfaces.rest.dto.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 정렬 방향 (오름차순/내림차순) */

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/request/AuctionHistorySearchRequest.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionhistory/interfaces/rest/dto/response/AuctionHistoryDetailResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionhistory.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItem.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.Instant;
 import java.util.List;
-import lombok.*;
 
 /** 실시간 경매장에서 판매 중인 아이템 정보. V15 마이그레이션에서 auction_item → auction_realtime_item으로 변경됨. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitem/domain/entity/AuctionRealtimeItemOption.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionitem.domain.entity;
 
 import jakarta.persistence.*;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 /** 실시간 경매장 아이템(auction_realtime_item)에 연결된 아이템 옵션 정보. */
 @Entity

--- a/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
+++ b/src/main/java/until/the/eternity/auctionitemoption/domain/entity/AuctionHistoryItemOption.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionitemoption.domain.entity;
 
 import jakarta.persistence.*;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import until.the.eternity.auctionhistory.domain.entity.AuctionHistory;
+
+import java.util.UUID;
 
 /**
  * 경매장 거래 내역(auction_history)에 연결된 아이템 옵션 정보. V15 마이그레이션에서 auction_item_option →

--- a/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/scheduler/AuctionRealtimeScheduler.java
@@ -1,8 +1,5 @@
 package until.the.eternity.auctionrealtime.application.scheduler;
 
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +12,10 @@ import until.the.eternity.auctionrealtime.application.service.fetcher.AuctionRea
 import until.the.eternity.auctionrealtime.application.service.persister.AuctionRealtimePersister;
 import until.the.eternity.auctionrealtime.domain.service.fetcher.AuctionRealtimeFetcherPort.FetchResult;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * 실시간 경매장 데이터 수집 스케줄러.

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/AuctionRealtimeService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service;
 
-import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -19,6 +17,9 @@ import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeI
 import until.the.eternity.common.enums.ItemCategory;
 import until.the.eternity.common.response.PageResponseDto;
 import until.the.eternity.config.CacheNames;
+
+import java.time.Instant;
+import java.util.List;
 
 /** 실시간 경매장 데이터 Service. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/fetcher/AuctionRealtimeFetcher.java
@@ -1,7 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service.fetcher;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,6 +8,9 @@ import until.the.eternity.auctionrealtime.infrastructure.client.AuctionRealtimeC
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeListResponse;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 실시간 경매장 데이터 Fetcher 구현체.

--- a/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/application/service/persister/AuctionRealtimePersister.java
@@ -1,6 +1,5 @@
 package until.the.eternity.auctionrealtime.application.service.persister;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,6 +8,8 @@ import until.the.eternity.auctionrealtime.domain.mapper.OpenApiAuctionRealtimeMa
 import until.the.eternity.auctionrealtime.domain.service.persister.AuctionRealtimePersisterPort;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Persister 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/AuctionRealtimeMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.AuctionRealtimeDetailResponse;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.response.RealtimeItemOptionResponse;
+
+import java.util.List;
 
 /** AuctionRealtimeItem Entity to DTO mapper class. */
 @Mapper(componentModel = "spring")

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/mapper/OpenApiAuctionRealtimeMapper.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionrealtime.domain.mapper;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import org.mapstruct.*;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 /** OpenApiAuctionRealtimeResponse → AuctionRealtimeItem Entity 변환 Mapper. */
 @Mapper(componentModel = "spring", uses = OpenApiRealtimeItemOptionMapper.class)

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/repository/AuctionRealtimeItemRepositoryPort.java
@@ -1,13 +1,14 @@
 package until.the.eternity.auctionrealtime.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionRealtimeItem Repository Port (Hexagonal Architecture). */
 public interface AuctionRealtimeItemRepositoryPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/fetcher/AuctionRealtimeFetcherPort.java
@@ -1,8 +1,9 @@
 package until.the.eternity.auctionrealtime.domain.service.fetcher;
 
-import java.util.List;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Fetcher Port. */
 public interface AuctionRealtimeFetcherPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/domain/service/persister/AuctionRealtimePersisterPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionrealtime.domain.service.persister;
 
-import java.util.List;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.interfaces.external.dto.OpenApiAuctionRealtimeResponse;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.List;
 
 /** 실시간 경매장 데이터 Persister Port. */
 public interface AuctionRealtimePersisterPort {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepository.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
-import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
+
+import java.time.Instant;
 
 /** AuctionRealtimeItem JPA Repository. */
 public interface AuctionRealtimeItemRepository extends JpaRepository<AuctionRealtimeItem, Long> {

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeItemRepositoryPortImpl.java
@@ -1,9 +1,6 @@
 package until.the.eternity.auctionrealtime.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,6 +10,10 @@ import until.the.eternity.auctionitem.domain.entity.AuctionRealtimeItem;
 import until.the.eternity.auctionrealtime.domain.repository.AuctionRealtimeItemRepositoryPort;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /** AuctionRealtimeItemRepositoryPort 구현체. */
 @Slf4j

--- a/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/infrastructure/persistence/AuctionRealtimeQueryDslRepository.java
@@ -8,11 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -28,6 +23,12 @@ import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItem;
 import until.the.eternity.auctionitem.domain.entity.QAuctionRealtimeItemOption;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.DateAuctionExpireRequest;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /** Nexon Open API /auction/list 응답 리스트 DTO. */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/external/dto/OpenApiAuctionRealtimeResponse.java
@@ -2,9 +2,10 @@ package until.the.eternity.auctionrealtime.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
+
 import java.time.Instant;
 import java.util.List;
-import until.the.eternity.auctionitemoption.domain.dto.external.OpenApiAuctionItemOptionResponse;
 
 /** Nexon Open API /auction/list 응답 DTO. 현재 경매장에서 판매 중인 아이템 정보. */
 public record OpenApiAuctionRealtimeResponse(

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/AuctionRealtimeSearchRequest.java
@@ -1,11 +1,12 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.EnchantSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.ItemOptionSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.MetalwareSearchRequest;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.PriceSearchRequest;
+
+import java.util.List;
 
 /** 실시간 경매장 검색 조건 DTO */
 @Schema(description = "실시간 경매장 검색 조건")

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/request/RealtimeSortField.java
@@ -3,6 +3,7 @@ package until.the.eternity.auctionrealtime.interfaces.rest.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 실시간 경매장 정렬 필드 */

--- a/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
+++ b/src/main/java/until/the/eternity/auctionrealtime/interfaces/rest/dto/response/AuctionRealtimeDetailResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionrealtime.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
@@ -2,8 +2,6 @@ package until.the.eternity.auctionsearchoption.application.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -14,6 +12,9 @@ import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOpt
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.FieldMetadata;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
 import until.the.eternity.config.CacheNames;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/application/service/AuctionSearchOptionService.java
@@ -30,7 +30,8 @@ public class AuctionSearchOptionService {
      */
     @Cacheable(
             cacheNames = CacheNames.SEARCH_OPTION_ALL_ACTIVE,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).all()")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).all()",
+            sync = true)
     @Transactional(readOnly = true)
     public List<SearchOptionMetadataResponse> getAllActiveSearchOptions() {
         List<AuctionSearchOptionMetadata> entities = repositoryPort.findAllActive();

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
@@ -9,7 +9,13 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
-@Table(name = "auction_search_option_metadata")
+@Table(
+        name = "auction_search_option_metadata",
+        indexes = {
+            @Index(
+                    name = "idx_search_option_active_display_order",
+                    columnList = "is_active, display_order")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuctionSearchOptionMetadata {

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/entity/AuctionSearchOptionMetadata.java
@@ -1,12 +1,13 @@
 package until.the.eternity.auctionsearchoption.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/domain/repository/AuctionSearchOptionRepositoryPort.java
@@ -1,7 +1,8 @@
 package until.the.eternity.auctionsearchoption.domain.repository;
 
-import java.util.List;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+import java.util.List;
 
 public interface AuctionSearchOptionRepositoryPort {
 

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionJpaRepository.java
@@ -1,9 +1,10 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
+
+import java.util.List;
 
 @Repository
 interface AuctionSearchOptionJpaRepository

--- a/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/infrastructure/persistence/AuctionSearchOptionRepositoryPortImpl.java
@@ -1,10 +1,11 @@
 package until.the.eternity.auctionsearchoption.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import until.the.eternity.auctionsearchoption.domain.entity.AuctionSearchOptionMetadata;
 import until.the.eternity.auctionsearchoption.domain.repository.AuctionSearchOptionRepositoryPort;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
@@ -2,8 +2,10 @@ package until.the.eternity.auctionsearchoption.interfaces.rest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +27,8 @@ public class AuctionSearchOptionController {
     public ResponseEntity<ApiResponse<List<SearchOptionMetadataResponse>>> getSearchOptions() {
         List<SearchOptionMetadataResponse> searchOptions = service.getAllActiveSearchOptions();
 
-        return ResponseEntity.ok(
-                ApiResponse.success("SEARCH_OPTION_SUCCESS", "검색 옵션 조회 성공", searchOptions));
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofDays(1)).cachePublic())
+                .body(ApiResponse.success("SEARCH_OPTION_SUCCESS", "검색 옵션 조회 성공", searchOptions));
     }
 }

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/AuctionSearchOptionController.java
@@ -2,8 +2,6 @@ package until.the.eternity.auctionsearchoption.interfaces.rest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.auctionsearchoption.application.service.AuctionSearchOptionService;
 import until.the.eternity.auctionsearchoption.interfaces.rest.dto.response.SearchOptionMetadataResponse;
 import until.the.eternity.common.response.ApiResponse;
+
+import java.time.Duration;
+import java.util.List;
 
 @Tag(name = "Auction Search Option", description = "경매 검색 옵션 API")
 @RestController

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/FieldMetadata.java
@@ -2,6 +2,7 @@ package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 @Schema(description = "검색 조건 필드 메타데이터")

--- a/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
+++ b/src/main/java/until/the/eternity/auctionsearchoption/interfaces/rest/dto/response/SearchOptionMetadataResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.auctionsearchoption.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Map;
 
 @Schema(description = "검색 옵션 메타데이터 응답")

--- a/src/main/java/until/the/eternity/batchlog/application/service/BatchExecutionLogService.java
+++ b/src/main/java/until/the/eternity/batchlog/application/service/BatchExecutionLogService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.batchlog.application.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,6 +10,9 @@ import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.domain.enums.TriggerType;
 import until.the.eternity.batchlog.domain.repository.BatchExecutionLogRepositoryPort;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/batchlog/domain/entity/BatchExecutionLog.java
+++ b/src/main/java/until/the/eternity/batchlog/domain/entity/BatchExecutionLog.java
@@ -1,12 +1,13 @@
 package until.the.eternity.batchlog.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.domain.enums.TriggerType;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "batch_execution_log")

--- a/src/main/java/until/the/eternity/batchlog/domain/repository/BatchExecutionLogRepositoryPort.java
+++ b/src/main/java/until/the/eternity/batchlog/domain/repository/BatchExecutionLogRepositoryPort.java
@@ -1,10 +1,11 @@
 package until.the.eternity.batchlog.domain.repository;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
+
+import java.util.List;
 
 public interface BatchExecutionLogRepositoryPort {
 

--- a/src/main/java/until/the/eternity/batchlog/infrastructure/persistence/BatchExecutionLogJpaRepository.java
+++ b/src/main/java/until/the/eternity/batchlog/infrastructure/persistence/BatchExecutionLogJpaRepository.java
@@ -1,11 +1,12 @@
 package until.the.eternity.batchlog.infrastructure.persistence;
 
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
+
+import java.util.Optional;
 
 public interface BatchExecutionLogJpaRepository extends JpaRepository<BatchExecutionLog, Long> {
 

--- a/src/main/java/until/the/eternity/batchlog/infrastructure/persistence/BatchExecutionLogRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/batchlog/infrastructure/persistence/BatchExecutionLogRepositoryPortImpl.java
@@ -1,8 +1,5 @@
 package until.the.eternity.batchlog.infrastructure.persistence;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +7,10 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.domain.repository.BatchExecutionLogRepositoryPort;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/batchlog/interfaces/rest/controller/BatchExecutionLogController.java
+++ b/src/main/java/until/the/eternity/batchlog/interfaces/rest/controller/BatchExecutionLogController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +18,8 @@ import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.interfaces.rest.dto.response.BatchExecutionLogResponse;
 import until.the.eternity.common.response.PageResponseDto;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/batch-logs")

--- a/src/main/java/until/the/eternity/batchlog/interfaces/rest/dto/response/BatchExecutionLogResponse.java
+++ b/src/main/java/until/the/eternity/batchlog/interfaces/rest/dto/response/BatchExecutionLogResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.batchlog.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import until.the.eternity.batchlog.domain.entity.BatchExecutionLog;
 import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.domain.enums.TriggerType;
+
+import java.time.LocalDateTime;
 
 @Schema(description = "배치 실행 로그 응답 DTO")
 public record BatchExecutionLogResponse(

--- a/src/main/java/until/the/eternity/common/annotation/BatchLog.java
+++ b/src/main/java/until/the/eternity/common/annotation/BatchLog.java
@@ -1,7 +1,8 @@
 package until.the.eternity.common.annotation;
 
-import java.lang.annotation.*;
 import until.the.eternity.batchlog.domain.enums.BatchType;
+
+import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/until/the/eternity/common/annotation/MetalwareParameters.java
+++ b/src/main/java/until/the/eternity/common/annotation/MetalwareParameters.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)

--- a/src/main/java/until/the/eternity/common/aspect/BatchExecutionLoggingAspect.java
+++ b/src/main/java/until/the/eternity/common/aspect/BatchExecutionLoggingAspect.java
@@ -1,6 +1,5 @@
 package until.the.eternity.common.aspect;
 
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -16,6 +15,8 @@ import until.the.eternity.batchlog.domain.enums.BatchType;
 import until.the.eternity.batchlog.domain.enums.TriggerType;
 import until.the.eternity.common.annotation.BatchLog;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Aspect

--- a/src/main/java/until/the/eternity/common/enums/ItemCategory.java
+++ b/src/main/java/until/the/eternity/common/enums/ItemCategory.java
@@ -1,11 +1,12 @@
 package until.the.eternity.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/enums/SortDirection.java
+++ b/src/main/java/until/the/eternity/common/enums/SortDirection.java
@@ -3,8 +3,9 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Arrays;
 import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
 
 /** 정렬 방향 (오름차순/내림차순) */
 @Schema(description = "정렬 방향", enumAsRef = true)

--- a/src/main/java/until/the/eternity/common/enums/SortField.java
+++ b/src/main/java/until/the/eternity/common/enums/SortField.java
@@ -3,6 +3,7 @@ package until.the.eternity.common.enums;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** 정렬 필드 */

--- a/src/main/java/until/the/eternity/common/enums/UserRole.java
+++ b/src/main/java/until/the/eternity/common/enums/UserRole.java
@@ -1,12 +1,13 @@
 package until.the.eternity.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionCode.java
@@ -1,10 +1,10 @@
 package until.the.eternity.common.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/until/the/eternity/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package until.the.eternity.common.exception;
 
-import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import until.the.eternity.common.response.ApiResponse;
+
+import static until.the.eternity.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
+++ b/src/main/java/until/the/eternity/common/filter/GatewayAuthFilter.java
@@ -4,9 +4,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +16,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import until.the.eternity.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.common.enums.UserRole;
 import until.the.eternity.common.util.IpAddressUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Gateway에서 전달한 인증 헤더(X-Auth-*)를 기반으로 Spring Security의 Authentication을 생성하는 필터

--- a/src/main/java/until/the/eternity/common/response/ApiResponse.java
+++ b/src/main/java/until/the/eternity/common/response/ApiResponse.java
@@ -1,8 +1,9 @@
 package until.the.eternity.common.response;
 
-import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.Instant;
 
 @Getter
 public class ApiResponse<T> {

--- a/src/main/java/until/the/eternity/common/response/PageResponseDto.java
+++ b/src/main/java/until/the/eternity/common/response/PageResponseDto.java
@@ -1,6 +1,7 @@
 package until.the.eternity.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 @Schema(description = "페이지 응답 객체")

--- a/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
+++ b/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
@@ -1,6 +1,5 @@
 package until.the.eternity.common.util;
 
-import java.time.LocalDate;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
@@ -9,6 +8,8 @@ import until.the.eternity.common.request.PageRequestDto;
 import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.request.MetalwareAttributeInfoSearchRequest;
+
+import java.time.LocalDate;
 
 public final class CacheKeyBuilder {
 

--- a/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
+++ b/src/main/java/until/the/eternity/common/util/CacheKeyBuilder.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Sort;
 import until.the.eternity.auctionhistory.interfaces.rest.dto.request.AuctionHistorySearchRequest;
 import until.the.eternity.auctionrealtime.interfaces.rest.dto.request.AuctionRealtimeSearchRequest;
 import until.the.eternity.common.request.PageRequestDto;
+import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.request.MetalwareAttributeInfoSearchRequest;
 
@@ -94,8 +95,10 @@ public final class CacheKeyBuilder {
     }
 
     public static String buildStatisticsSubcategoryKey(
-            String subCategory, LocalDate startDate, LocalDate endDate) {
-        return normalize(subCategory)
+            String topCategory, String subCategory, LocalDate startDate, LocalDate endDate) {
+        return normalize(topCategory)
+                + ":"
+                + normalize(subCategory)
                 + ":"
                 + String.valueOf(startDate)
                 + ":"
@@ -181,6 +184,13 @@ public final class CacheKeyBuilder {
                 + pageable.getPageSize()
                 + ":"
                 + pageable.getSort();
+    }
+
+    public static String buildHornBugleRecentKey(
+            String serverName, HornBuglePageRequestDto pageRequest) {
+        int page = pageRequest != null ? pageRequest.getResolvedPage() : 1;
+        int size = pageRequest != null ? pageRequest.getResolvedSize() : 20;
+        return normalize(serverName) + ":" + page + ":" + size;
     }
 
     private static String normalize(String value) {

--- a/src/main/java/until/the/eternity/common/util/SegongOptionParser.java
+++ b/src/main/java/until/the/eternity/common/util/SegongOptionParser.java
@@ -1,8 +1,9 @@
 package until.the.eternity.common.util;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 세공 옵션의 option_value를 파싱하여 스킬명(option_value), 레벨(option_value2), 설명(option_desc)을 분리하는 유틸리티.

--- a/src/main/java/until/the/eternity/config/CacheNames.java
+++ b/src/main/java/until/the/eternity/config/CacheNames.java
@@ -37,6 +37,9 @@ public final class CacheNames {
     public static final String METALWARE_INFO_ALL = "metalware-info:all";
     public static final String METALWARE_ATTRIBUTE_INFO_SEARCH = "metalware-attribute-info:search";
 
+    // ===== 뿔피리 =====
+    public static final String HORN_BUGLE_RECENT = "horn-bugle:recent";
+
     // ===== 통계 (일간) =====
     public static final String STATISTICS_ITEM_DAILY = "statistics:item:daily";
     public static final String STATISTICS_SUBCATEGORY_DAILY = "statistics:subcategory:daily";

--- a/src/main/java/until/the/eternity/config/CacheStartupWarmupRunner.java
+++ b/src/main/java/until/the/eternity/config/CacheStartupWarmupRunner.java
@@ -1,7 +1,9 @@
 package until.the.eternity.config;
 
 import java.time.LocalDate;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -20,6 +22,8 @@ import until.the.eternity.auctionsearchoption.application.service.AuctionSearchO
 import until.the.eternity.common.enums.ItemCategory;
 import until.the.eternity.common.enums.SortDirection;
 import until.the.eternity.enchantinfo.application.service.EnchantInfoService;
+import until.the.eternity.hornBugle.application.service.HornBugleService;
+import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.iteminfo.application.service.ItemInfoService;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
@@ -46,6 +50,7 @@ public class CacheStartupWarmupRunner implements ApplicationRunner {
 
     private final AuctionHistoryCacheWarmupService auctionHistoryCacheWarmupService;
     private final AuctionRealtimeCacheWarmupService auctionRealtimeCacheWarmupService;
+    private final HornBugleService hornBugleService;
     private final AuctionSearchOptionService auctionSearchOptionService;
     private final ItemInfoService itemInfoService;
     private final EnchantInfoService enchantInfoService;
@@ -66,6 +71,11 @@ public class CacheStartupWarmupRunner implements ApplicationRunner {
     @Value("${app.cache.warmup.ranking-limit:50}")
     private int startupRankingLimit;
 
+    private record StatisticsWarmupTarget(
+            String itemName, String topCategory, String subCategory) {}
+
+    private record RankingCategoryWarmupTarget(String topCategory, String subCategory) {}
+
     @Override
     public void run(ApplicationArguments args) {
         log.info("[Cache Warmup] Startup warmup scheduled (async)");
@@ -77,6 +87,7 @@ public class CacheStartupWarmupRunner implements ApplicationRunner {
 
         tryWarm("auction-history", auctionHistoryCacheWarmupService::evictAndWarm);
         tryWarm("auction-realtime", auctionRealtimeCacheWarmupService::evictAndWarm);
+        tryWarm("horn-bugle", this::warmHornBugleCaches);
         tryWarm("search-option", auctionSearchOptionService::getAllActiveSearchOptions);
         tryWarm("item-info", this::warmItemInfoCaches);
         tryWarm("enchant-info", this::warmEnchantCaches);
@@ -117,29 +128,57 @@ public class CacheStartupWarmupRunner implements ApplicationRunner {
         }
     }
 
+    private void warmHornBugleCaches() {
+        hornBugleService.search(null, null, new HornBuglePageRequestDto(1, 20));
+    }
+
     private void warmRankingCaches() {
-        int limit =
-                startupRankingLimit > 0
-                        ? Math.min(startupRankingLimit, RankingConstants.MAX_LIMIT)
-                        : RankingConstants.DEFAULT_LIMIT;
-        priceRankingService.getTodayHighestPrice(limit);
-        priceRankingService.getWeekHighestPrice(limit);
-        priceRankingService.getTodayLargestVolume(limit);
+        for (int limit : rankingWarmupLimits()) {
+            priceRankingService.getTodayHighestPrice(limit);
+            priceRankingService.getWeekHighestPrice(limit);
+            priceRankingService.getTodayLargestVolume(limit);
 
-        volumeRankingService.getTodayPopular(limit);
-        volumeRankingService.getWeekPopular(limit);
+            volumeRankingService.getTodayPopular(limit);
+            volumeRankingService.getWeekPopular(limit);
 
-        priceChangeRankingService.getPriceSurge(limit);
-        priceChangeRankingService.getPriceDrop(limit);
-        priceChangeRankingService.getVolumeSurge(limit);
+            priceChangeRankingService.getPriceSurge(limit);
+            priceChangeRankingService.getPriceDrop(limit);
+            priceChangeRankingService.getVolumeSurge(limit);
 
-        String defaultTopCategory = ItemCategory.ONE_HANDED_WEAPON.getTopCategory();
-        String defaultSubCategory = ItemCategory.ONE_HANDED_WEAPON.getSubCategory();
-        categoryRankingService.getCategoryTopPriced(defaultTopCategory, defaultSubCategory, limit);
-        categoryRankingService.getCategoryPopular(defaultTopCategory, defaultSubCategory, limit);
+            for (RankingCategoryWarmupTarget target : rankingCategoryWarmupTargets()) {
+                categoryRankingService.getCategoryTopPriced(
+                        target.topCategory(), target.subCategory(), limit);
+                categoryRankingService.getCategoryPopular(
+                        target.topCategory(), target.subCategory(), limit);
+            }
 
-        allTimeRankingService.getAllTimeHighestPrice(limit);
-        allTimeRankingService.getMonthLargestVolume(limit);
+            allTimeRankingService.getAllTimeHighestPrice(limit);
+            allTimeRankingService.getMonthLargestVolume(limit);
+        }
+    }
+
+    private Set<Integer> rankingWarmupLimits() {
+        Set<Integer> limits = new LinkedHashSet<>();
+        addRankingWarmupLimit(limits, 20);
+        addRankingWarmupLimit(limits, RankingConstants.DEFAULT_LIMIT);
+        addRankingWarmupLimit(limits, startupRankingLimit);
+        return limits;
+    }
+
+    private void addRankingWarmupLimit(Set<Integer> limits, int limit) {
+        if (limit <= 0) {
+            return;
+        }
+        limits.add(Math.min(limit, RankingConstants.MAX_LIMIT));
+    }
+
+    private List<RankingCategoryWarmupTarget> rankingCategoryWarmupTargets() {
+        return List.of(
+                new RankingCategoryWarmupTarget(
+                        ItemCategory.ONE_HANDED_WEAPON.getTopCategory(),
+                        ItemCategory.ONE_HANDED_WEAPON.getSubCategory()),
+                new RankingCategoryWarmupTarget("기타", "기타"),
+                new RankingCategoryWarmupTarget("소모품", "포션"));
     }
 
     private void warmStatisticsCaches() {
@@ -150,21 +189,33 @@ public class CacheStartupWarmupRunner implements ApplicationRunner {
         }
 
         ItemInfoResponse sample = items.get(0);
+        List<StatisticsWarmupTarget> targets =
+                List.of(
+                        new StatisticsWarmupTarget(
+                                sample.name(), sample.topCategory(), sample.subCategory()),
+                        new StatisticsWarmupTarget("향기로운 꿀 우유", "기타", "기타"),
+                        new StatisticsWarmupTarget("축복의 포션", "소모품", "포션"));
         LocalDate dailyStart = LocalDate.now().minusDays(14);
         LocalDate weeklyStart = LocalDate.now().minusMonths(2);
         LocalDate end = LocalDate.now();
 
-        itemDailyStatisticsService.search(
-                sample.name(), sample.subCategory(), sample.topCategory(), dailyStart, end);
-        subcategoryDailyStatisticsService.search(
-                sample.topCategory(), sample.subCategory(), dailyStart, end);
-        topCategoryDailyStatisticsService.search(sample.topCategory(), dailyStart, end);
+        for (StatisticsWarmupTarget target : targets) {
+            itemDailyStatisticsService.search(
+                    target.itemName(), target.subCategory(), target.topCategory(), dailyStart, end);
+            subcategoryDailyStatisticsService.search(
+                    target.topCategory(), target.subCategory(), dailyStart, end);
+            topCategoryDailyStatisticsService.search(target.topCategory(), dailyStart, end);
 
-        itemWeeklyStatisticsService.search(
-                sample.name(), sample.subCategory(), sample.topCategory(), weeklyStart, end);
-        subcategoryWeeklyStatisticsService.search(
-                sample.topCategory(), sample.subCategory(), weeklyStart, end);
-        topCategoryWeeklyStatisticsService.search(sample.topCategory(), weeklyStart, end);
+            itemWeeklyStatisticsService.search(
+                    target.itemName(),
+                    target.subCategory(),
+                    target.topCategory(),
+                    weeklyStart,
+                    end);
+            subcategoryWeeklyStatisticsService.search(
+                    target.topCategory(), target.subCategory(), weeklyStart, end);
+            topCategoryWeeklyStatisticsService.search(target.topCategory(), weeklyStart, end);
+        }
     }
 
     private void tryWarm(String domain, Runnable runnable) {

--- a/src/main/java/until/the/eternity/config/CacheStartupWarmupRunner.java
+++ b/src/main/java/until/the/eternity/config/CacheStartupWarmupRunner.java
@@ -1,9 +1,5 @@
 package until.the.eternity.config;
 
-import java.time.LocalDate;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -34,6 +30,11 @@ import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareIn
 import until.the.eternity.ranking.application.service.*;
 import until.the.eternity.ranking.util.RankingConstants;
 import until.the.eternity.statistics.application.service.*;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/RedisCacheErrorHandler.java
+++ b/src/main/java/until/the/eternity/config/RedisCacheErrorHandler.java
@@ -1,9 +1,10 @@
 package until.the.eternity.config;
 
-import java.net.ConnectException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.interceptor.CacheErrorHandler;
+
+import java.net.ConnectException;
 
 /**
  * Redis 장애 시 캐시 오류를 로깅만 하고 예외를 전파하지 않는 핸들러.

--- a/src/main/java/until/the/eternity/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/config/RedisConfig.java
@@ -6,9 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
@@ -21,6 +18,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableCaching

--- a/src/main/java/until/the/eternity/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/config/RedisConfig.java
@@ -91,9 +91,12 @@ public class RedisConfig implements CachingConfigurer {
         configs.put(CacheNames.ITEM_INFO_DETAIL, defaultConfig.entryTtl(masterTtl));
         configs.put(CacheNames.ITEM_INFO_SUMMARY, defaultConfig.entryTtl(masterTtl));
         configs.put(CacheNames.ENCHANT_INFO_ALL, defaultConfig.entryTtl(masterTtl));
-        configs.put(CacheNames.ENCHANT_INFO_FULLNAMES, defaultConfig.entryTtl(masterTtl));
-        configs.put(CacheNames.METALWARE_INFO_ALL, defaultConfig.entryTtl(masterTtl));
+        configs.put(CacheNames.ENCHANT_INFO_FULLNAMES, defaultConfig.entryTtl(Duration.ofHours(6)));
+        configs.put(CacheNames.METALWARE_INFO_ALL, defaultConfig.entryTtl(Duration.ofHours(6)));
         configs.put(CacheNames.METALWARE_ATTRIBUTE_INFO_SEARCH, defaultConfig.entryTtl(masterTtl));
+
+        // 뿔피리 최신 목록 - 5분 배치 데이터의 짧은 TTL 캐시
+        configs.put(CacheNames.HORN_BUGLE_RECENT, defaultConfig.entryTtl(Duration.ofMinutes(2)));
 
         // 통계 - 30분 TTL (이벤트 기반 eviction으로 실시간 반영)
         Duration statsTtl = Duration.ofMinutes(30);

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiFilters.java
@@ -1,11 +1,12 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiRetryPolicy.java
@@ -1,10 +1,11 @@
 package until.the.eternity.config.openapi;
 
-import java.time.Duration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
+
+import java.time.Duration;
 
 /** Nexon OPEN API 전용 재시도(Back-off) 정책. */
 @Component

--- a/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
+++ b/src/main/java/until/the/eternity/config/openapi/OpenApiWebClientProperties.java
@@ -2,9 +2,10 @@ package until.the.eternity.config.openapi;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 /** 외부 API용 WebClient 설정값 홀더 application.yml 사용) */
 @Validated

--- a/src/main/java/until/the/eternity/enchantinfo/application/service/EnchantInfoService.java
+++ b/src/main/java/until/the/eternity/enchantinfo/application/service/EnchantInfoService.java
@@ -39,7 +39,8 @@ public class EnchantInfoService {
             cacheNames = CacheNames.ENCHANT_INFO_FULLNAMES,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildEnchantInfoFullnamesKey(#affixPosition)")
+                            + ".buildEnchantInfoFullnamesKey(#affixPosition)",
+            sync = true)
     public List<String> findAllFullnames(String affixPosition) {
         if (affixPosition != null) {
             if (!ALLOWED_AFFIX_POSITIONS.contains(affixPosition)) {

--- a/src/main/java/until/the/eternity/enchantinfo/application/service/EnchantInfoService.java
+++ b/src/main/java/until/the/eternity/enchantinfo/application/service/EnchantInfoService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.enchantinfo.application.service;
 
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -16,6 +14,9 @@ import until.the.eternity.enchantinfo.domain.exception.EnchantInfoExceptionCode;
 import until.the.eternity.enchantinfo.domain.repository.EnchantInfoRepositoryPort;
 import until.the.eternity.enchantinfo.interfaces.rest.dto.response.EnchantInfoResponse;
 import until.the.eternity.enchantinfo.interfaces.rest.dto.response.EnchantInfoSyncResponse;
+
+import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/enchantinfo/domain/exception/EnchantInfoExceptionCode.java
+++ b/src/main/java/until/the/eternity/enchantinfo/domain/exception/EnchantInfoExceptionCode.java
@@ -1,11 +1,11 @@
 package until.the.eternity.enchantinfo.domain.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import until.the.eternity.common.exception.ExceptionCode;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/enchantinfo/domain/repository/EnchantInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/enchantinfo/domain/repository/EnchantInfoRepositoryPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.enchantinfo.domain.repository;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.enchantinfo.infrastructure.persistence.EnchantInfoEntity;
+
+import java.util.List;
 
 public interface EnchantInfoRepositoryPort {
 

--- a/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoEntity.java
+++ b/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoEntity.java
@@ -5,7 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "enchant_info")
+@Table(
+        name = "enchant_info",
+        indexes = {
+            @Index(name = "idx_enchant_info_affix_position_id", columnList = "affix_position, id")
+        })
 @Getter
 @NoArgsConstructor
 public class EnchantInfoEntity {

--- a/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoJpaRepository.java
@@ -1,9 +1,10 @@
 package until.the.eternity.enchantinfo.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface EnchantInfoJpaRepository extends JpaRepository<EnchantInfoEntity, Long> {
 

--- a/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/enchantinfo/infrastructure/persistence/EnchantInfoRepositoryPortImpl.java
@@ -1,11 +1,12 @@
 package until.the.eternity.enchantinfo.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.enchantinfo.domain.repository.EnchantInfoRepositoryPort;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/enchantinfo/interfaces/rest/controller/EnchantInfoController.java
+++ b/src/main/java/until/the/eternity/enchantinfo/interfaces/rest/controller/EnchantInfoController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.enchantinfo.application.service.EnchantInfoService;
 import until.the.eternity.enchantinfo.interfaces.rest.dto.request.EnchantInfoPageRequestDto;
 import until.the.eternity.enchantinfo.interfaces.rest.dto.response.EnchantInfoResponse;
 import until.the.eternity.enchantinfo.interfaces.rest.dto.response.EnchantInfoSyncResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/enchant-infos")

--- a/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/runner/HornBugleIndexRunner.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.application.runner;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -13,6 +12,8 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexService;
+
+import java.util.List;
 
 /**
  * 서버 재기동 시 DB 데이터를 Elasticsearch에 일괄 색인하는 Runner. application.yml에서

--- a/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/scheduler/HornBugleScheduler.java
@@ -1,10 +1,5 @@
 package until.the.eternity.hornBugle.application.scheduler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +14,12 @@ import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHist
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.kafka.application.HornBugleKafkaProducerService;
 import until.the.eternity.hornBugle.kafka.dto.UserVerificationVerifyEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
@@ -1,8 +1,5 @@
 package until.the.eternity.hornBugle.application.service;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -21,6 +18,10 @@ import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleIndexS
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.request.HornBuglePageRequestDto;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
+++ b/src/main/java/until/the/eternity/hornBugle/application/service/HornBugleService.java
@@ -4,10 +4,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.common.response.PageResponseDto;
+import until.the.eternity.config.CacheNames;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.domain.mapper.HornBugleMapper;
@@ -47,11 +50,13 @@ public class HornBugleService {
      * @return 저장된 건수
      */
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.HORN_BUGLE_RECENT, allEntries = true)
     public int saveAll(HornBugleServer server, List<OpenApiHornBugleHistoryResponse> responses) {
         return saveAllAndReturnSaved(server, responses).size();
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.HORN_BUGLE_RECENT, allEntries = true)
     public List<HornBugleWorldHistory> saveAllAndReturnSaved(
             HornBugleServer server, List<OpenApiHornBugleHistoryResponse> responses) {
         if (responses == null || responses.isEmpty()) {
@@ -95,6 +100,13 @@ public class HornBugleService {
      * @return 페이징 응답
      */
     @Transactional(readOnly = true)
+    @Cacheable(
+            cacheNames = CacheNames.HORN_BUGLE_RECENT,
+            key =
+                    "T(until.the.eternity.common.util.CacheKeyBuilder)"
+                            + ".buildHornBugleRecentKey(#serverName, #pageRequest)",
+            condition = "#keyword == null or #keyword.isBlank()",
+            sync = true)
     public PageResponseDto<HornBugleHistoryResponse> search(
             String serverName, String keyword, HornBuglePageRequestDto pageRequest) {
 

--- a/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/entity/HornBugleWorldHistory.java
@@ -1,8 +1,9 @@
 package until.the.eternity.hornBugle.domain.entity;
 
 import jakarta.persistence.*;
-import java.time.Instant;
 import lombok.*;
+
+import java.time.Instant;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/enums/HornBugleServer.java
@@ -1,10 +1,11 @@
 package until.the.eternity.hornBugle.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/mapper/HornBugleMapper.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.domain.mapper;
 
-import java.time.Instant;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
@@ -8,6 +7,8 @@ import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.infrastructure.elasticsearch.HornBugleDocument;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
 import until.the.eternity.hornBugle.interfaces.rest.dto.response.HornBugleHistoryResponse;
+
+import java.time.Instant;
 
 @Mapper(componentModel = "spring")
 public interface HornBugleMapper {

--- a/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/repository/HornBugleRepositoryPort.java
@@ -1,11 +1,12 @@
 package until.the.eternity.hornBugle.domain.repository;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 public interface HornBugleRepositoryPort {
 

--- a/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
+++ b/src/main/java/until/the/eternity/hornBugle/domain/service/HornBugleDuplicateChecker.java
@@ -1,10 +1,5 @@
 package until.the.eternity.hornBugle.domain.service;
 
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -12,6 +7,12 @@ import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.enums.HornBugleServer;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
 import until.the.eternity.hornBugle.interfaces.external.dto.OpenApiHornBugleHistoryResponse;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Component

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleDocument.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +10,8 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
 
 @Document(indexName = "horn_bugle_world_history")
 @Setting(settingPath = "elasticsearch/horn-bugle-settings.json")

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/elasticsearch/HornBugleIndexService.java
@@ -2,7 +2,6 @@ package until.the.eternity.hornBugle.infrastructure.elasticsearch;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -17,6 +16,8 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Service;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleJpaRepository.java
@@ -1,14 +1,15 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface HornBugleJpaRepository extends JpaRepository<HornBugleWorldHistory, Long> {

--- a/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/hornBugle/infrastructure/persistence/HornBugleRepositoryPortImpl.java
@@ -1,9 +1,6 @@
 package until.the.eternity.hornBugle.infrastructure.persistence;
 
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -12,6 +9,10 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.hornBugle.domain.entity.HornBugleWorldHistory;
 import until.the.eternity.hornBugle.domain.repository.HornBugleRepositoryPort;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryListResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OpenApiHornBugleHistoryListResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/external/dto/OpenApiHornBugleHistoryResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.interfaces.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 
 public record OpenApiHornBugleHistoryResponse(

--- a/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
+++ b/src/main/java/until/the/eternity/hornBugle/interfaces/rest/dto/response/HornBugleHistoryResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.hornBugle.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
 @Schema(description = "뿔피리 히스토리 응답")

--- a/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
+++ b/src/main/java/until/the/eternity/hornBugle/kafka/application/HornBugleKafkaProducerService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.hornBugle.kafka.application;
 
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -8,6 +7,8 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 import until.the.eternity.common.constant.KafkaTopicConstant;
 import until.the.eternity.hornBugle.kafka.dto.UserVerificationVerifyEvent;
+
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
+++ b/src/main/java/until/the/eternity/iteminfo/application/service/ItemInfoService.java
@@ -1,9 +1,5 @@
 package until.the.eternity.iteminfo.application.service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -25,6 +21,11 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/entity/ItemInfoId.java
@@ -2,8 +2,9 @@ package until.the.eternity.iteminfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.io.Serializable;
 import lombok.*;
+
+import java.io.Serializable;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/exception/ItemInfoExceptionCode.java
@@ -1,11 +1,11 @@
 package until.the.eternity.iteminfo.domain.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import until.the.eternity.common.exception.ExceptionCode;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/iteminfo/domain/repository/ItemInfoRepositoryPort.java
@@ -1,11 +1,12 @@
 package until.the.eternity.iteminfo.domain.repository;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 public interface ItemInfoRepositoryPort {
     List<ItemInfo> findAll();

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoJpaRepository.java
@@ -1,11 +1,12 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.ItemInfoId;
+
+import java.util.List;
 
 public interface ItemInfoJpaRepository
         extends JpaRepository<ItemInfo, ItemInfoId>, JpaSpecificationExecutor<ItemInfo> {

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoQueryDslRepository.java
@@ -3,7 +3,6 @@ package until.the.eternity.iteminfo.infrastructure.persistence;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -12,6 +11,8 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.entity.QItemInfo;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/iteminfo/infrastructure/persistence/ItemInfoRepositoryPortImpl.java
@@ -1,6 +1,5 @@
 package until.the.eternity.iteminfo.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +8,8 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
 import until.the.eternity.iteminfo.domain.repository.ItemInfoRepositoryPort;
 import until.the.eternity.iteminfo.interfaces.rest.dto.request.ItemInfoSearchRequest;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -32,7 +34,9 @@ public class ItemInfoController {
     @Operation(summary = "카테고리 정보", description = "아이템 상위 카테고리, 하위 카테고리 정보 조회")
     public ResponseEntity<ApiResponse<List<ItemCategoryResponse>>> findItemCategories() {
         List<ItemCategoryResponse> itemCategories = itemInfoService.findItemCategories();
-        return ResponseEntity.ok(ApiResponse.success(itemCategories));
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofDays(1)).cachePublic())
+                .body(ApiResponse.success(itemCategories));
     }
 
     @Operation(summary = "모든 아이템 정보 조회", description = "시스템에 저장된 모든 아이템 정보를 조회합니다.")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/controller/ItemInfoController.java
@@ -4,8 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.CacheControl;
@@ -21,6 +19,9 @@ import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemCategoryResp
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSummaryResponse;
 import until.the.eternity.iteminfo.interfaces.rest.dto.response.ItemInfoSyncResponse;
+
+import java.time.Duration;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/item-infos")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
-import java.util.Arrays;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import until.the.eternity.common.enums.ItemCategory;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemCategoryResponse.java
@@ -2,7 +2,6 @@ package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import until.the.eternity.common.enums.ItemCategory;
@@ -11,17 +10,20 @@ import until.the.eternity.common.enums.ItemCategory;
 @Builder
 public class ItemCategoryResponse {
 
+    private static final List<ItemCategoryResponse> CACHED_RESPONSES =
+            Arrays.stream(ItemCategory.values())
+                    .map(
+                            itemCategory ->
+                                    ItemCategoryResponse.builder()
+                                            .subCategory(itemCategory.getSubCategory())
+                                            .topCategory(itemCategory.getTopCategory())
+                                            .build())
+                    .toList();
+
     private String subCategory;
     private String topCategory;
 
     public static List<ItemCategoryResponse> from() {
-        return Arrays.stream(ItemCategory.values())
-                .map(
-                        itemCategory ->
-                                ItemCategoryResponse.builder()
-                                        .subCategory(itemCategory.getSubCategory())
-                                        .topCategory(itemCategory.getTopCategory())
-                                        .build())
-                .collect(Collectors.toList());
+        return CACHED_RESPONSES;
     }
 }

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @Schema(description = "아이템 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSummaryResponse.java
@@ -1,10 +1,11 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import until.the.eternity.iteminfo.domain.entity.ItemInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @Schema(description = "아이템 정보 요약 응답 DTO")

--- a/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
+++ b/src/main/java/until/the/eternity/iteminfo/interfaces/rest/dto/response/ItemInfoSyncResponse.java
@@ -1,8 +1,9 @@
 package until.the.eternity.iteminfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 @Schema(description = "아이템 정보 동기화 응답 DTO")

--- a/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/application/service/ItemOptionInfoService.java
@@ -1,12 +1,13 @@
 package until.the.eternity.itemoptioninfo.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/entity/ItemOptionInfoId.java
@@ -2,11 +2,12 @@ package until.the.eternity.itemoptioninfo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.io.Serializable;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 @Embeddable
 @Getter

--- a/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/domain/repository/ItemOptionInfoRepositoryPort.java
@@ -1,9 +1,10 @@
 package until.the.eternity.itemoptioninfo.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ItemOptionInfoRepositoryPort {
     List<ItemOptionInfo> findAll();

--- a/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/infrastructure/persistence/ItemOptionInfoRepositoryPortImpl.java
@@ -1,12 +1,13 @@
 package until.the.eternity.itemoptioninfo.infrastructure.persistence;
 
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfo;
 import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.repository.ItemOptionInfoRepositoryPort;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
+++ b/src/main/java/until/the/eternity/itemoptioninfo/interfaces/rest/controller/ItemOptionInfoController.java
@@ -4,8 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,6 +14,9 @@ import until.the.eternity.itemoptioninfo.domain.entity.ItemOptionInfoId;
 import until.the.eternity.itemoptioninfo.domain.mapper.ItemOptionInfoMapper;
 import until.the.eternity.itemoptioninfo.interfaces.rest.dto.request.ItemOptionInfoRequest;
 import until.the.eternity.itemoptioninfo.interfaces.rest.dto.response.ItemOptionInfoResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/item-option-infos")

--- a/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
@@ -21,7 +21,8 @@ public class MetalwareInfoService {
 
     @Cacheable(
             cacheNames = CacheNames.METALWARE_INFO_ALL,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).all()")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).all()",
+            sync = true)
     public List<MetalwareInfoResponse> findAll() {
         List<String> metalwares = metalwareInfoRepository.findAllMetalwares();
         return MetalwareInfoResponse.from(metalwares);

--- a/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/application/service/MetalwareInfoService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.metalwareinfo.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -11,6 +10,8 @@ import until.the.eternity.config.CacheNames;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoSyncResponse;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MetalwareInfoJpaRepository extends JpaRepository<MetalwareInfoEntity, String> {
 

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MetalwareInfoJpaRepository extends JpaRepository<MetalwareInfoEntity, String> {
 
-    @Query("SELECT m.metalware FROM MetalwareInfoEntity m")
+    @Query("SELECT m.metalware FROM MetalwareInfoEntity m ORDER BY m.metalware ASC")
     List<String> findAllMetalwares();
 
     @Modifying

--- a/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/infrastructure/persistence/MetalwareInfoRepositoryPortImpl.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.infrastructure.persistence;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.metalwareinfo.domain.repository.MetalwareInfoRepositoryPort;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
@@ -3,8 +3,6 @@ package until.the.eternity.metalwareinfo.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.metalwareinfo.application.service.MetalwareInfoService;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoResponse;
 import until.the.eternity.metalwareinfo.interfaces.rest.dto.response.MetalwareInfoSyncResponse;
+
+import java.time.Duration;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/metalware-infos")

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/controller/MetalwareInfoController.java
@@ -3,8 +3,10 @@ package until.the.eternity.metalwareinfo.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,8 +28,10 @@ public class MetalwareInfoController {
     // TODO: 세공 레벨별 능력치, 최대 레벨, 한계 돌파 최대 레벨은 수기로 추가 후 조회 시 사용
     @Operation(summary = "모든 세공 정보 조회", description = "시스템에 저장된 모든 세공 정보를 조회합니다.")
     @GetMapping
-    public List<MetalwareInfoResponse> getAllMetalwareInfos() {
-        return metalwareInfoService.findAll();
+    public ResponseEntity<List<MetalwareInfoResponse>> getAllMetalwareInfos() {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofHours(6)).cachePublic())
+                .body(metalwareInfoService.findAll());
     }
 
     @Operation(

--- a/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
+++ b/src/main/java/until/the/eternity/metalwareinfo/interfaces/rest/dto/response/MetalwareInfoResponse.java
@@ -1,9 +1,10 @@
 package until.the.eternity.metalwareinfo.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Builder;
 
 @Builder
 @Schema(description = "세공 정보 응답 DTO")

--- a/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
@@ -21,7 +21,8 @@ public class AllTimeRankingService {
     /** 역대 최고가 거래 TOP N (API 11) - auction_history 전체 스캔, 1시간 TTL */
     @Cacheable(
             cacheNames = CacheNames.RANKING_ALLTIME_HIGHEST,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<AllTimeRankingResponse> getAllTimeHighestPrice(int limit) {
         List<Object[]> results = rankingRepository.findAllTimeHighestPrice(limit);
         return rankingMapper.toAllTimeRankingResponses(results);
@@ -30,7 +31,8 @@ public class AllTimeRankingService {
     /** 이번 달 최대 거래액 TOP N (API 12) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_ALLTIME_MONTH_VOLUME,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<AllTimeRankingResponse> getMonthLargestVolume(int limit) {
         List<Object[]> results = rankingRepository.findMonthLargestVolume(limit);
         return rankingMapper.toAllTimeRankingResponses(results);

--- a/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/AllTimeRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -9,6 +8,8 @@ import until.the.eternity.config.CacheNames;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
@@ -24,11 +24,15 @@ public class CategoryRankingService {
             cacheNames = CacheNames.RANKING_CATEGORY_HIGHEST,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildRankingCategoryKey(#topCategory, #subCategory, #limit)")
+                            + ".buildRankingCategoryKey(#topCategory, #subCategory, #limit)",
+            sync = true)
     public List<PriceRankingResponse> getCategoryTopPriced(
             String topCategory, String subCategory, int limit) {
         List<Object[]> results =
-                rankingRepository.findCategoryTopPriced(topCategory, subCategory, limit);
+                hasSubCategory(subCategory)
+                        ? rankingRepository.findCategoryTopPricedByTopAndSubCategory(
+                                topCategory, subCategory, limit)
+                        : rankingRepository.findCategoryTopPricedByTopCategory(topCategory, limit);
         return rankingMapper.toPriceRankingResponses(results);
     }
 
@@ -37,11 +41,19 @@ public class CategoryRankingService {
             cacheNames = CacheNames.RANKING_CATEGORY_POPULAR,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildRankingCategoryKey(#topCategory, #subCategory, #limit)")
+                            + ".buildRankingCategoryKey(#topCategory, #subCategory, #limit)",
+            sync = true)
     public List<VolumeRankingResponse> getCategoryPopular(
             String topCategory, String subCategory, int limit) {
         List<Object[]> results =
-                rankingRepository.findCategoryPopular(topCategory, subCategory, limit);
+                hasSubCategory(subCategory)
+                        ? rankingRepository.findCategoryPopularByTopAndSubCategory(
+                                topCategory, subCategory, limit)
+                        : rankingRepository.findCategoryPopularByTopCategory(topCategory, limit);
         return rankingMapper.toVolumeRankingResponses(results);
+    }
+
+    private boolean hasSubCategory(String subCategory) {
+        return subCategory != null && !subCategory.isBlank();
     }
 }

--- a/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/CategoryRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -10,6 +9,8 @@ import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -10,6 +9,8 @@ import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceChangeRankingService.java
@@ -22,7 +22,8 @@ public class PriceChangeRankingService {
     /** 가격 급등 TOP N (API 6) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_CHANGE_PRICE_SURGE,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<PriceChangeRankingResponse> getPriceSurge(int limit) {
         List<Object[]> results = rankingRepository.findPriceSurge(limit);
         return rankingMapper.toPriceChangeRankingResponses(results);
@@ -31,7 +32,8 @@ public class PriceChangeRankingService {
     /** 가격 급락 TOP N (API 7) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_CHANGE_PRICE_DROP,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<PriceChangeRankingResponse> getPriceDrop(int limit) {
         List<Object[]> results = rankingRepository.findPriceDrop(limit);
         return rankingMapper.toPriceChangeRankingResponses(results);
@@ -40,7 +42,8 @@ public class PriceChangeRankingService {
     /** 거래량 급증 TOP N (API 8) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_CHANGE_VOLUME_SURGE,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<VolumeChangeRankingResponse> getVolumeSurge(int limit) {
         List<Object[]> results = rankingRepository.findVolumeSurge(limit);
         return rankingMapper.toVolumeChangeRankingResponses(results);

--- a/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/PriceRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -9,6 +8,8 @@ import until.the.eternity.config.CacheNames;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
@@ -1,6 +1,5 @@
 package until.the.eternity.ranking.application.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -9,6 +8,8 @@ import until.the.eternity.config.CacheNames;
 import until.the.eternity.ranking.domain.mapper.RankingMapper;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
 import until.the.eternity.ranking.repository.RankingRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
+++ b/src/main/java/until/the/eternity/ranking/application/service/VolumeRankingService.java
@@ -21,7 +21,8 @@ public class VolumeRankingService {
     /** 오늘의 인기 아이템 TOP N (API 4) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_VOLUME_TODAY_POPULAR,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<VolumeRankingResponse> getTodayPopular(int limit) {
         List<Object[]> results = rankingRepository.findTodayPopular(limit);
         return rankingMapper.toVolumeRankingResponses(results);
@@ -30,7 +31,8 @@ public class VolumeRankingService {
     /** 이번 주 인기 아이템 TOP N (API 5) */
     @Cacheable(
             cacheNames = CacheNames.RANKING_VOLUME_WEEK_POPULAR,
-            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)")
+            key = "T(until.the.eternity.common.util.CacheKeyBuilder).byLimit(#limit)",
+            sync = true)
     public List<VolumeRankingResponse> getWeekPopular(int limit) {
         List<Object[]> results = rankingRepository.findWeekPopular(limit);
         return rankingMapper.toVolumeRankingResponses(results);

--- a/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
+++ b/src/main/java/until/the/eternity/ranking/domain/mapper/RankingMapper.java
@@ -1,5 +1,8 @@
 package until.the.eternity.ranking.domain.mapper;
 
+import org.springframework.stereotype.Component;
+import until.the.eternity.ranking.interfaces.rest.dto.response.*;
+
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -7,8 +10,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.springframework.stereotype.Component;
-import until.the.eternity.ranking.interfaces.rest.dto.response.*;
 
 @Component
 public class RankingMapper {

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/AllTimeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.AllTimeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.AllTimeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/all-time")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/CategoryRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,8 @@ import until.the.eternity.ranking.application.service.CategoryRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.CategoryRankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/category")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceChangeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,8 @@ import until.the.eternity.ranking.application.service.PriceChangeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceChangeRankingResponse;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeChangeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/price-change")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/PriceRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.PriceRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.PriceRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/price")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/controller/VolumeRankingController.java
@@ -3,7 +3,6 @@ package until.the.eternity.ranking.interfaces.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +14,8 @@ import until.the.eternity.common.response.ApiResponse;
 import until.the.eternity.ranking.application.service.VolumeRankingService;
 import until.the.eternity.ranking.interfaces.rest.dto.request.RankingSearchRequest;
 import until.the.eternity.ranking.interfaces.rest.dto.response.VolumeRankingResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/rankings/volume")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/AllTimeRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
 @Schema(description = "역대 기록 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceChangeRankingResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 
 @Schema(description = "가격 변동 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/PriceRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeChangeRankingResponse.java
@@ -1,6 +1,7 @@
 package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 
 @Schema(description = "거래량 변동 랭킹 응답")

--- a/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
+++ b/src/main/java/until/the/eternity/ranking/interfaces/rest/dto/response/VolumeRankingResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.ranking.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 

--- a/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
+++ b/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
@@ -1,10 +1,11 @@
 package until.the.eternity.ranking.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
+
+import java.util.List;
 
 public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
+++ b/src/main/java/until/the/eternity/ranking/repository/RankingRepository.java
@@ -199,7 +199,7 @@ public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Lo
 
     // ===== 카테고리별 랭킹 (Category Ranking) =====
 
-    /** 카테고리별 최고가 TOP N (API 9) */
+    /** 상위 카테고리별 최고가 TOP N (API 9) */
     @Query(
             value =
                     """
@@ -215,17 +215,40 @@ public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Lo
                     FROM item_daily_statistics i
                     WHERE i.date_auction_buy = CURDATE()
                       AND i.item_top_category = :topCategory
-                      AND (:subCategory IS NULL OR i.item_sub_category = :subCategory)
                     ORDER BY i.max_price DESC
                     LIMIT :limit
                     """,
             nativeQuery = true)
-    List<Object[]> findCategoryTopPriced(
+    List<Object[]> findCategoryTopPricedByTopCategory(
+            @Param("topCategory") String topCategory, @Param("limit") int limit);
+
+    /** 상위/하위 카테고리별 최고가 TOP N (API 9) */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.max_price,
+                        i.avg_price,
+                        i.total_volume,
+                        i.total_quantity,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                      AND i.item_top_category = :topCategory
+                      AND i.item_sub_category = :subCategory
+                    ORDER BY i.max_price DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findCategoryTopPricedByTopAndSubCategory(
             @Param("topCategory") String topCategory,
             @Param("subCategory") String subCategory,
             @Param("limit") int limit);
 
-    /** 카테고리별 인기 아이템 TOP N (API 10) - 거래 수량 기준 */
+    /** 상위 카테고리별 인기 아이템 TOP N (API 10) - 거래 수량 기준 */
     @Query(
             value =
                     """
@@ -240,12 +263,34 @@ public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Lo
                     FROM item_daily_statistics i
                     WHERE i.date_auction_buy = CURDATE()
                       AND i.item_top_category = :topCategory
-                      AND (:subCategory IS NULL OR i.item_sub_category = :subCategory)
                     ORDER BY i.total_quantity DESC
                     LIMIT :limit
                     """,
             nativeQuery = true)
-    List<Object[]> findCategoryPopular(
+    List<Object[]> findCategoryPopularByTopCategory(
+            @Param("topCategory") String topCategory, @Param("limit") int limit);
+
+    /** 상위/하위 카테고리별 인기 아이템 TOP N (API 10) - 거래 수량 기준 */
+    @Query(
+            value =
+                    """
+                    SELECT
+                        i.item_name,
+                        i.item_top_category,
+                        i.item_sub_category,
+                        i.total_quantity,
+                        i.total_volume,
+                        i.avg_price,
+                        i.date_auction_buy
+                    FROM item_daily_statistics i
+                    WHERE i.date_auction_buy = CURDATE()
+                      AND i.item_top_category = :topCategory
+                      AND i.item_sub_category = :subCategory
+                    ORDER BY i.total_quantity DESC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true)
+    List<Object[]> findCategoryPopularByTopAndSubCategory(
             @Param("topCategory") String topCategory,
             @Param("subCategory") String subCategory,
             @Param("limit") int limit);
@@ -266,7 +311,7 @@ public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Lo
                         (ah.auction_price_per_unit * ah.item_count) AS total_price,
                         ah.date_auction_buy
                     FROM auction_history ah
-                    ORDER BY ah.auction_price_per_unit DESC
+                    ORDER BY ah.auction_price_per_unit DESC, ah.auction_buy_id DESC
                     LIMIT :limit
                     """,
             nativeQuery = true)
@@ -288,7 +333,7 @@ public interface RankingRepository extends JpaRepository<ItemDailyStatistics, Lo
                     FROM auction_history ah
                     WHERE YEAR(ah.date_auction_buy) = YEAR(CURDATE())
                       AND MONTH(ah.date_auction_buy) = MONTH(CURDATE())
-                    ORDER BY (ah.auction_price_per_unit * ah.item_count) DESC
+                    ORDER BY (ah.auction_price_per_unit * ah.item_count) DESC, ah.auction_buy_id DESC
                     LIMIT :limit
                     """,
             nativeQuery = true)

--- a/src/main/java/until/the/eternity/statistics/application/service/ItemDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/ItemDailyStatisticsService.java
@@ -2,15 +2,12 @@ package until.the.eternity.statistics.application.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
-import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
-import until.the.eternity.statistics.domain.mapper.ItemDailyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemDailyStatisticsResponse;
 import until.the.eternity.statistics.repository.daily.ItemDailyStatisticsRepository;
 
@@ -20,14 +17,14 @@ import until.the.eternity.statistics.repository.daily.ItemDailyStatisticsReposit
 public class ItemDailyStatisticsService {
 
     private final ItemDailyStatisticsRepository repository;
-    private final ItemDailyStatisticsMapper mapper;
 
     /** 아이템별 일간 통계 조회 (itemName, subCategory, topCategory, 날짜 범위) */
     @Cacheable(
             cacheNames = CacheNames.STATISTICS_ITEM_DAILY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsItemKey(#itemName, #subCategory, #topCategory, #startDate, #endDate)")
+                            + ".buildStatisticsItemKey(#itemName, #subCategory, #topCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<ItemDailyStatisticsResponse> search(
             String itemName,
@@ -38,10 +35,7 @@ public class ItemDailyStatisticsService {
         until.the.eternity.statistics.util.DateRangeValidator.validateDailyDateRange(
                 startDate, endDate);
 
-        List<ItemDailyStatistics> results =
-                repository.findByItemAndDateRange(
-                        itemName, subCategory, topCategory, startDate, endDate);
-
-        return results.stream().map(mapper::toDto).collect(Collectors.toList());
+        return repository.findByItemAndDateRange(
+                itemName, subCategory, topCategory, startDate, endDate);
     }
 }

--- a/src/main/java/until/the/eternity/statistics/application/service/ItemDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/ItemDailyStatisticsService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -10,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemDailyStatisticsResponse;
 import until.the.eternity.statistics.repository.daily.ItemDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/ItemWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/ItemWeeklyStatisticsService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -10,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemWeeklyStatisticsResponse;
 import until.the.eternity.statistics.repository.weekly.ItemWeeklyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/ItemWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/ItemWeeklyStatisticsService.java
@@ -2,15 +2,12 @@ package until.the.eternity.statistics.application.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
-import until.the.eternity.statistics.domain.entity.weekly.ItemWeeklyStatistics;
-import until.the.eternity.statistics.domain.mapper.ItemWeeklyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemWeeklyStatisticsResponse;
 import until.the.eternity.statistics.repository.weekly.ItemWeeklyStatisticsRepository;
 
@@ -20,14 +17,14 @@ import until.the.eternity.statistics.repository.weekly.ItemWeeklyStatisticsRepos
 public class ItemWeeklyStatisticsService {
 
     private final ItemWeeklyStatisticsRepository repository;
-    private final ItemWeeklyStatisticsMapper mapper;
 
     /** 아이템별 주간 통계 조회 (itemName, subCategory, topCategory, 날짜 범위) */
     @Cacheable(
             cacheNames = CacheNames.STATISTICS_ITEM_WEEKLY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsItemKey(#itemName, #subCategory, #topCategory, #startDate, #endDate)")
+                            + ".buildStatisticsItemKey(#itemName, #subCategory, #topCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<ItemWeeklyStatisticsResponse> search(
             String itemName,
@@ -38,10 +35,7 @@ public class ItemWeeklyStatisticsService {
         until.the.eternity.statistics.util.DateRangeValidator.validateWeeklyDateRange(
                 startDate, endDate);
 
-        List<ItemWeeklyStatistics> results =
-                repository.findByItemAndDateRange(
-                        itemName, subCategory, topCategory, startDate, endDate);
-
-        return results.stream().map(mapper::toDto).collect(Collectors.toList());
+        return repository.findByItemAndDateRange(
+                itemName, subCategory, topCategory, startDate, endDate);
     }
 }

--- a/src/main/java/until/the/eternity/statistics/application/service/SubcategoryDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/SubcategoryDailyStatisticsService.java
@@ -27,7 +27,8 @@ public class SubcategoryDailyStatisticsService {
             cacheNames = CacheNames.STATISTICS_SUBCATEGORY_DAILY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsSubcategoryKey(#subCategory, #startDate, #endDate)")
+                            + ".buildStatisticsSubcategoryKey(#topCategory, #subCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<SubcategoryDailyStatisticsResponse> search(
             String topCategory, String subCategory, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/until/the/eternity/statistics/application/service/SubcategoryDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/SubcategoryDailyStatisticsService.java
@@ -1,8 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -13,6 +10,10 @@ import until.the.eternity.statistics.domain.entity.daily.SubcategoryDailyStatist
 import until.the.eternity.statistics.domain.mapper.SubcategoryDailyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.SubcategoryDailyStatisticsResponse;
 import until.the.eternity.statistics.repository.daily.SubcategoryDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/SubcategoryWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/SubcategoryWeeklyStatisticsService.java
@@ -1,8 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -13,6 +10,10 @@ import until.the.eternity.statistics.domain.entity.weekly.SubcategoryWeeklyStati
 import until.the.eternity.statistics.domain.mapper.SubcategoryWeeklyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.SubcategoryWeeklyStatisticsResponse;
 import until.the.eternity.statistics.repository.weekly.SubcategoryWeeklyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/SubcategoryWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/SubcategoryWeeklyStatisticsService.java
@@ -27,7 +27,8 @@ public class SubcategoryWeeklyStatisticsService {
             cacheNames = CacheNames.STATISTICS_SUBCATEGORY_WEEKLY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsSubcategoryKey(#subCategory, #startDate, #endDate)")
+                            + ".buildStatisticsSubcategoryKey(#topCategory, #subCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<SubcategoryWeeklyStatisticsResponse> search(
             String topCategory, String subCategory, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/until/the/eternity/statistics/application/service/TopCategoryDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/TopCategoryDailyStatisticsService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -10,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
 import until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryDailyStatisticsResponse;
 import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/TopCategoryDailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/TopCategoryDailyStatisticsService.java
@@ -2,15 +2,12 @@ package until.the.eternity.statistics.application.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.config.CacheNames;
-import until.the.eternity.statistics.domain.entity.daily.TopCategoryDailyStatistics;
-import until.the.eternity.statistics.domain.mapper.TopCategoryDailyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryDailyStatisticsResponse;
 import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatisticsRepository;
 
@@ -20,23 +17,20 @@ import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatistics
 public class TopCategoryDailyStatisticsService {
 
     private final TopCategoryDailyStatisticsRepository repository;
-    private final TopCategoryDailyStatisticsMapper mapper;
 
     /** 탑카테고리별 일간 통계 조회 (topCategory, 날짜 범위) */
     @Cacheable(
             cacheNames = CacheNames.STATISTICS_TOPCATEGORY_DAILY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsTopCategoryKey(#topCategory, #startDate, #endDate)")
+                            + ".buildStatisticsTopCategoryKey(#topCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<TopCategoryDailyStatisticsResponse> search(
             String topCategory, LocalDate startDate, LocalDate endDate) {
         until.the.eternity.statistics.util.DateRangeValidator.validateDailyDateRange(
                 startDate, endDate);
 
-        List<TopCategoryDailyStatistics> results =
-                repository.findByTopCategoryAndDateRange(topCategory, startDate, endDate);
-
-        return results.stream().map(mapper::toDto).collect(Collectors.toList());
+        return repository.findByTopCategoryAndDateRange(topCategory, startDate, endDate);
     }
 }

--- a/src/main/java/until/the/eternity/statistics/application/service/TopCategoryWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/TopCategoryWeeklyStatisticsService.java
@@ -1,8 +1,5 @@
 package until.the.eternity.statistics.application.service;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -13,6 +10,10 @@ import until.the.eternity.statistics.domain.entity.weekly.TopCategoryWeeklyStati
 import until.the.eternity.statistics.domain.mapper.TopCategoryWeeklyStatisticsMapper;
 import until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryWeeklyStatisticsResponse;
 import until.the.eternity.statistics.repository.weekly.TopCategoryWeeklyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/application/service/TopCategoryWeeklyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/application/service/TopCategoryWeeklyStatisticsService.java
@@ -27,7 +27,8 @@ public class TopCategoryWeeklyStatisticsService {
             cacheNames = CacheNames.STATISTICS_TOPCATEGORY_WEEKLY,
             key =
                     "T(until.the.eternity.common.util.CacheKeyBuilder)"
-                            + ".buildStatisticsTopCategoryKey(#topCategory, #startDate, #endDate)")
+                            + ".buildStatisticsTopCategoryKey(#topCategory, #startDate, #endDate)",
+            sync = true)
     @Transactional(readOnly = true)
     public List<TopCategoryWeeklyStatisticsResponse> search(
             String topCategory, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
@@ -13,7 +13,14 @@ import lombok.*;
         indexes = {
             @Index(
                     name = "idx_item_daily_statistics_item_name_date",
-                    columnList = "item_name, date_auction_buy")
+                    columnList = "item_name, date_auction_buy"),
+            @Index(
+                    name = "idx_item_daily_date_total_quantity",
+                    columnList = "date_auction_buy, total_quantity DESC"),
+            @Index(
+                    name = "idx_item_daily_item_category_date",
+                    columnList =
+                            "item_name, item_top_category, item_sub_category, date_auction_buy")
         },
         uniqueConstraints = {
             @UniqueConstraint(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/ItemDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/SubcategoryDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/daily/TopCategoryDailyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.daily;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/ItemWeeklyStatistics.java
@@ -13,7 +13,14 @@ import lombok.*;
         indexes = {
             @Index(
                     name = "idx_item_weekly_statistics_item_name_year_week",
-                    columnList = "item_name, year, week_number")
+                    columnList = "item_name, year, week_number"),
+            @Index(
+                    name = "idx_item_weekly_item_category_start_date",
+                    columnList =
+                            "item_name, item_top_category, item_sub_category, week_start_date"),
+            @Index(
+                    name = "idx_item_weekly_year_week_total_quantity",
+                    columnList = "year, week_number, total_quantity DESC")
         },
         uniqueConstraints = {
             @UniqueConstraint(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/SubcategoryWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
@@ -2,10 +2,11 @@ package until.the.eternity.statistics.domain.entity.weekly;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.*;
 
 @Entity
 @Table(

--- a/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
+++ b/src/main/java/until/the/eternity/statistics/domain/entity/weekly/TopCategoryWeeklyStatistics.java
@@ -13,7 +13,10 @@ import lombok.*;
         indexes = {
             @Index(
                     name = "idx_top_category_weekly_statistics_category_year_week",
-                    columnList = "item_top_category, year, week_number")
+                    columnList = "item_top_category, year, week_number"),
+            @Index(
+                    name = "idx_top_category_weekly_statistics_category_start_date",
+                    columnList = "item_top_category, week_start_date")
         },
         uniqueConstraints = {
             @UniqueConstraint(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/DailyStatisticsSearchRequest.java
@@ -1,8 +1,9 @@
 package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "일간 통계 검색 요청")
 public record DailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "아이템별 일간 통계 검색 요청")
 public record ItemDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/ItemWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "아이템별 주간 통계 검색 요청")
 public record ItemWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "서브카테고리별 일간 통계 검색 요청")
 public record SubcategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/SubcategoryWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "서브카테고리별 주간 통계 검색 요청")
 public record SubcategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryDailyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "탑카테고리별 일간 통계 검색 요청")
 public record TopCategoryDailyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/request/TopCategoryWeeklyStatisticsSearchRequest.java
@@ -2,8 +2,9 @@ package until.the.eternity.statistics.interfaces.rest.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Schema(description = "탑카테고리별 주간 통계 검색 요청")
 public record TopCategoryWeeklyStatisticsSearchRequest(

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/ItemWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/SubcategoryWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryDailyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
+++ b/src/main/java/until/the/eternity/statistics/interfaces/rest/dto/response/TopCategoryWeeklyStatisticsResponse.java
@@ -2,6 +2,7 @@ package until.the.eternity.statistics.interfaces.rest.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
+import until.the.eternity.statistics.interfaces.rest.dto.response.ItemDailyStatisticsResponse;
 
 public interface ItemDailyStatisticsRepository extends JpaRepository<ItemDailyStatistics, Long> {
 
@@ -22,11 +23,27 @@ public interface ItemDailyStatisticsRepository extends JpaRepository<ItemDailySt
      * @return 해당 조건의 일간 통계 리스트
      */
     @Query(
-            "SELECT i FROM ItemDailyStatistics i WHERE i.itemName = :itemName "
-                    + "AND i.itemSubCategory = :subCategory AND i.itemTopCategory = :topCategory "
-                    + "AND i.dateAuctionBuy BETWEEN :startDate AND :endDate "
-                    + "ORDER BY i.dateAuctionBuy ASC")
-    List<ItemDailyStatistics> findByItemAndDateRange(
+            """
+            SELECT new until.the.eternity.statistics.interfaces.rest.dto.response.ItemDailyStatisticsResponse(
+                i.id,
+                i.itemName,
+                i.dateAuctionBuy,
+                i.minPrice,
+                i.maxPrice,
+                i.avgPrice,
+                i.totalVolume,
+                i.totalQuantity,
+                i.createdAt,
+                i.updatedAt
+            )
+            FROM ItemDailyStatistics i
+            WHERE i.itemName = :itemName
+              AND i.itemSubCategory = :subCategory
+              AND i.itemTopCategory = :topCategory
+              AND i.dateAuctionBuy BETWEEN :startDate AND :endDate
+            ORDER BY i.dateAuctionBuy ASC
+            """)
+    List<ItemDailyStatisticsResponse> findByItemAndDateRange(
             @Param("itemName") String itemName,
             @Param("subCategory") String subCategory,
             @Param("topCategory") String topCategory,

--- a/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/ItemDailyStatisticsRepository.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +7,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.ItemDailyStatistics;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemDailyStatisticsResponse;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ItemDailyStatisticsRepository extends JpaRepository<ItemDailyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/SubcategoryDailyStatisticsRepository.java
@@ -1,13 +1,14 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.SubcategoryDailyStatistics;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SubcategoryDailyStatisticsRepository
         extends JpaRepository<SubcategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.repository.daily;
 
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +7,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.TopCategoryDailyStatistics;
 import until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryDailyStatisticsResponse;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TopCategoryDailyStatisticsRepository
         extends JpaRepository<TopCategoryDailyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/daily/TopCategoryDailyStatisticsRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.daily.TopCategoryDailyStatistics;
+import until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryDailyStatisticsResponse;
 
 public interface TopCategoryDailyStatisticsRepository
         extends JpaRepository<TopCategoryDailyStatistics, Long> {
@@ -21,10 +22,25 @@ public interface TopCategoryDailyStatisticsRepository
      * @return 해당 조건의 일간 통계 리스트
      */
     @Query(
-            "SELECT t FROM TopCategoryDailyStatistics t WHERE t.itemTopCategory = :topCategory "
-                    + "AND t.dateAuctionBuy BETWEEN :startDate AND :endDate "
-                    + "ORDER BY t.dateAuctionBuy ASC")
-    List<TopCategoryDailyStatistics> findByTopCategoryAndDateRange(
+            """
+            SELECT new until.the.eternity.statistics.interfaces.rest.dto.response.TopCategoryDailyStatisticsResponse(
+                t.id,
+                t.itemTopCategory,
+                t.dateAuctionBuy,
+                t.minPrice,
+                t.maxPrice,
+                t.avgPrice,
+                t.totalVolume,
+                t.totalQuantity,
+                t.createdAt,
+                t.updatedAt
+            )
+            FROM TopCategoryDailyStatistics t
+            WHERE t.itemTopCategory = :topCategory
+              AND t.dateAuctionBuy BETWEEN :startDate AND :endDate
+            ORDER BY t.dateAuctionBuy ASC
+            """)
+    List<TopCategoryDailyStatisticsResponse> findByTopCategoryAndDateRange(
             @Param("topCategory") String topCategory,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
@@ -1,6 +1,5 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +7,8 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.ItemWeeklyStatistics;
 import until.the.eternity.statistics.interfaces.rest.dto.response.ItemWeeklyStatisticsResponse;
+
+import java.util.List;
 
 public interface ItemWeeklyStatisticsRepository extends JpaRepository<ItemWeeklyStatistics, Long> {
 

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/ItemWeeklyStatisticsRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.ItemWeeklyStatistics;
+import until.the.eternity.statistics.interfaces.rest.dto.response.ItemWeeklyStatisticsResponse;
 
 public interface ItemWeeklyStatisticsRepository extends JpaRepository<ItemWeeklyStatistics, Long> {
 
@@ -21,11 +22,29 @@ public interface ItemWeeklyStatisticsRepository extends JpaRepository<ItemWeekly
      * @return 해당 조건의 주간 통계 리스트
      */
     @Query(
-            "SELECT i FROM ItemWeeklyStatistics i WHERE i.itemName = :itemName "
-                    + "AND i.itemSubCategory = :subCategory AND i.itemTopCategory = :topCategory "
-                    + "AND i.weekStartDate BETWEEN :startDate AND :endDate "
-                    + "ORDER BY i.year ASC, i.weekNumber ASC")
-    List<ItemWeeklyStatistics> findByItemAndDateRange(
+            """
+            SELECT new until.the.eternity.statistics.interfaces.rest.dto.response.ItemWeeklyStatisticsResponse(
+                i.id,
+                i.itemName,
+                i.year,
+                i.weekNumber,
+                i.weekStartDate,
+                i.minPrice,
+                i.maxPrice,
+                i.avgPrice,
+                i.totalVolume,
+                i.totalQuantity,
+                i.createdAt,
+                i.updatedAt
+            )
+            FROM ItemWeeklyStatistics i
+            WHERE i.itemName = :itemName
+              AND i.itemSubCategory = :subCategory
+              AND i.itemTopCategory = :topCategory
+              AND i.weekStartDate BETWEEN :startDate AND :endDate
+            ORDER BY i.weekStartDate ASC
+            """)
+    List<ItemWeeklyStatisticsResponse> findByItemAndDateRange(
             @Param("itemName") String itemName,
             @Param("subCategory") String subCategory,
             @Param("topCategory") String topCategory,

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/SubcategoryWeeklyStatisticsRepository.java
@@ -1,12 +1,13 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.SubcategoryWeeklyStatistics;
+
+import java.util.List;
 
 public interface SubcategoryWeeklyStatisticsRepository
         extends JpaRepository<SubcategoryWeeklyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
@@ -22,7 +22,7 @@ public interface TopCategoryWeeklyStatisticsRepository
     @Query(
             "SELECT t FROM TopCategoryWeeklyStatistics t WHERE t.itemTopCategory = :topCategory "
                     + "AND t.weekStartDate BETWEEN :startDate AND :endDate "
-                    + "ORDER BY t.year ASC, t.weekNumber ASC")
+                    + "ORDER BY t.weekStartDate ASC")
     List<TopCategoryWeeklyStatistics> findByTopCategoryAndDateRange(
             @Param("topCategory") String topCategory,
             @Param("startDate") java.time.LocalDate startDate,

--- a/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
+++ b/src/main/java/until/the/eternity/statistics/repository/weekly/TopCategoryWeeklyStatisticsRepository.java
@@ -1,12 +1,13 @@
 package until.the.eternity.statistics.repository.weekly;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.statistics.domain.entity.weekly.TopCategoryWeeklyStatistics;
+
+import java.util.List;
 
 public interface TopCategoryWeeklyStatisticsRepository
         extends JpaRepository<TopCategoryWeeklyStatistics, Long> {

--- a/src/main/java/until/the/eternity/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/service/DailyStatisticsService.java
@@ -1,7 +1,5 @@
 package until.the.eternity.statistics.service;
 
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -20,6 +18,9 @@ import until.the.eternity.statistics.application.service.TopCategoryDailyStatist
 import until.the.eternity.statistics.repository.daily.ItemDailyStatisticsRepository;
 import until.the.eternity.statistics.repository.daily.SubcategoryDailyStatisticsRepository;
 import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatisticsRepository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/until/the/eternity/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/until/the/eternity/statistics/service/DailyStatisticsService.java
@@ -1,12 +1,22 @@
 package until.the.eternity.statistics.service;
 
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import until.the.eternity.config.CacheNames;
+import until.the.eternity.ranking.application.service.VolumeRankingService;
+import until.the.eternity.ranking.util.RankingConstants;
+import until.the.eternity.statistics.application.service.ItemDailyStatisticsService;
+import until.the.eternity.statistics.application.service.TopCategoryDailyStatisticsService;
 import until.the.eternity.statistics.repository.daily.ItemDailyStatisticsRepository;
 import until.the.eternity.statistics.repository.daily.SubcategoryDailyStatisticsRepository;
 import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatisticsRepository;
@@ -16,9 +26,18 @@ import until.the.eternity.statistics.repository.daily.TopCategoryDailyStatistics
 @RequiredArgsConstructor
 public class DailyStatisticsService {
 
+    @Qualifier("applicationTaskExecutor")
+    private final TaskExecutor taskExecutor;
+
     private final ItemDailyStatisticsRepository itemDailyStatisticsRepository;
     private final SubcategoryDailyStatisticsRepository subcategoryDailyStatisticsRepository;
     private final TopCategoryDailyStatisticsRepository topCategoryDailyStatisticsRepository;
+    private final ItemDailyStatisticsService itemDailyStatisticsReadService;
+    private final TopCategoryDailyStatisticsService topCategoryDailyStatisticsReadService;
+    private final VolumeRankingService volumeRankingService;
+
+    private record DailyStatisticsWarmupTarget(
+            String itemName, String topCategory, String subCategory) {}
 
     /**
      * 당일의 경매 거래 내역을 기반으로 일간 통계를 업데이트 AuctionHistoryScheduler가 실행될 때마다 호출되어 당일 통계만 갱신 순서:
@@ -80,6 +99,7 @@ public class DailyStatisticsService {
         log.info(
                 "[Current Day Statistics] All current day statistics calculated successfully in {} ms",
                 System.currentTimeMillis() - start);
+        scheduleReadCacheWarmup("current-day");
     }
 
     /**
@@ -140,5 +160,55 @@ public class DailyStatisticsService {
         log.info(
                 "[Previous Day Statistics] All previous day statistics finalized successfully in {} ms",
                 System.currentTimeMillis() - start);
+        scheduleReadCacheWarmup("previous-day");
+    }
+
+    private void scheduleReadCacheWarmup(String reason) {
+        Runnable warmup = () -> warmReadCaches(reason);
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            taskExecutor.execute(warmup);
+                        }
+                    });
+            return;
+        }
+        taskExecutor.execute(warmup);
+    }
+
+    private void warmReadCaches(String reason) {
+        try {
+            LocalDate end = LocalDate.now();
+            LocalDate dailyStart = end.minusDays(14);
+
+            for (DailyStatisticsWarmupTarget target : dailyStatisticsWarmupTargets()) {
+                itemDailyStatisticsReadService.search(
+                        target.itemName(),
+                        target.subCategory(),
+                        target.topCategory(),
+                        dailyStart,
+                        end);
+                topCategoryDailyStatisticsReadService.search(target.topCategory(), dailyStart, end);
+            }
+
+            volumeRankingService.getTodayPopular(20);
+            volumeRankingService.getTodayPopular(RankingConstants.DEFAULT_LIMIT);
+
+            log.info("[Daily Statistics] Read cache warmup completed after {}", reason);
+        } catch (Exception e) {
+            log.warn(
+                    "[Daily Statistics] Read cache warmup failed after {}: {}",
+                    reason,
+                    e.getMessage(),
+                    e);
+        }
+    }
+
+    private List<DailyStatisticsWarmupTarget> dailyStatisticsWarmupTargets() {
+        return List.of(
+                new DailyStatisticsWarmupTarget("향기로운 꿀 우유", "기타", "기타"),
+                new DailyStatisticsWarmupTarget("축복의 포션", "소모품", "포션"));
     }
 }

--- a/src/main/resources/db/migration/V28__add_p99_read_api_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_p99_read_api_indexes.sql
@@ -1,0 +1,9 @@
+-- p99 조회 API 최적화 인덱스
+-- - weekly top category 통계 조회는 week_start_date 범위 조건을 사용한다.
+-- - enchant fullname 필터 조회는 affix_position 조건과 id 정렬을 함께 사용한다.
+
+CREATE INDEX idx_top_category_weekly_statistics_category_start_date
+    ON top_category_weekly_statistics (item_top_category, week_start_date);
+
+CREATE INDEX idx_enchant_info_affix_position_id
+    ON enchant_info (affix_position, id);

--- a/src/main/resources/db/migration/V29__add_next_p99_read_api_indexes.sql
+++ b/src/main/resources/db/migration/V29__add_next_p99_read_api_indexes.sql
@@ -1,0 +1,68 @@
+-- 추가 p99 조회 API 최적화 인덱스
+-- - 카테고리 랭킹은 당일/카테고리 조건으로 좁힌 뒤 가격/수량으로 정렬한다.
+-- - 가격 변동 랭킹은 오늘/어제 item_daily_statistics self join을 수행한다.
+-- - 주간 아이템 통계는 week_start_date 범위 조건을 사용한다.
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_daily_statistics'
+      AND index_name = 'idx_item_daily_date_top_sub_max_price'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_daily_date_top_sub_max_price ON item_daily_statistics (date_auction_buy, item_top_category, item_sub_category, max_price DESC)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_daily_statistics'
+      AND index_name = 'idx_item_daily_date_top_sub_quantity'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_daily_date_top_sub_quantity ON item_daily_statistics (date_auction_buy, item_top_category, item_sub_category, total_quantity DESC)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_daily_statistics'
+      AND index_name = 'idx_item_daily_date_item_category_change'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_daily_date_item_category_change ON item_daily_statistics (date_auction_buy, item_name(120), item_top_category(80), item_sub_category(80), avg_price, total_quantity)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_weekly_statistics'
+      AND index_name = 'idx_item_weekly_item_category_start_date'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_weekly_item_category_start_date ON item_weekly_statistics (item_name(120), item_top_category(80), item_sub_category(80), week_start_date)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/V30__add_remaining_p99_read_api_indexes.sql
+++ b/src/main/resources/db/migration/V30__add_remaining_p99_read_api_indexes.sql
@@ -1,0 +1,69 @@
+-- 잔여 p99 조회 API 최적화 인덱스
+-- - 전체 거래량 랭킹은 당일 통계를 거래 수량 기준으로 정렬한다.
+-- - 주간 거래량 랭킹은 연도/주차 통계를 거래 수량 기준으로 정렬한다.
+-- - 일간 아이템 통계는 itemName + category + date range 조건을 사용한다.
+-- - 검색 옵션 메타데이터는 active filtering + display order 정렬을 사용한다.
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_daily_statistics'
+      AND index_name = 'idx_item_daily_date_total_quantity'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_daily_date_total_quantity ON item_daily_statistics (date_auction_buy, total_quantity DESC)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_weekly_statistics'
+      AND index_name = 'idx_item_weekly_year_week_total_quantity'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_weekly_year_week_total_quantity ON item_weekly_statistics (year, week_number, total_quantity DESC)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_daily_statistics'
+      AND index_name = 'idx_item_daily_item_category_date'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_item_daily_item_category_date ON item_daily_statistics (item_name(120), item_top_category(80), item_sub_category(80), date_auction_buy)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction_search_option_metadata'
+      AND index_name = 'idx_search_option_active_display_order'
+);
+SET @ddl := IF(
+    @index_exists = 0,
+    'CREATE INDEX idx_search_option_active_display_order ON auction_search_option_metadata (is_active, display_order)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## 📋 상세 설명

- p99 타겟 조회 쿼리 패턴에 맞춘 인덱스 추가(Flyway + 일부 Entity 인덱스 반영)
- 랭킹/통계/메타데이터성 조회에 @Cacheable(sync=true) 적용 및 기동/배치 후 캐시 워밍업 로직 추가
- 통계 조회 일부를 DTO 프로젝션으로 변경해 조회 비용(엔티티 로딩/매핑)을 절감하고, 일부 컨트롤러에 HTTP 캐시 헤더 추가

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [ ] 이슈와 라벨이 등록되었나요 `이슈 미등록`
